### PR TITLE
fix: add missing @keyframes float to LandingPage hero section(#4)

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -48,6 +48,11 @@ export default function LandingPage() {
           50% { transform: translate3d(-5%, -4%, 0) scale(0.96); }
           100% { transform: translate3d(7%, 6%, 0) scale(1.06); }
         }
+        
+        @keyframes float {
+          0%, 100% { transform: translateY(0px); }
+          50% { transform: translateY(-20px); }
+        }
 
         @keyframes floatArrow {
           0% { transform: translateY(0); opacity: 0.5; }


### PR DESCRIPTION
Fixes(#4 )
# Summary

- [x] I linked the issue this PR addresses
- [x] I targeted `dev` as the base branch unless instructed otherwise
- [x] I kept the change scoped to one issue
- [ ] I added screenshots or recordings for UI changes
- [x] I added testing notes

## What changed
Added the missing `@keyframes float` declaration blocks inside `frontend/src/pages/LandingPage.tsx` to handle the positional rendering of the background mesh objects.

## Why this change is needed
The hero section elements were referencing an infinite layout animation named `float` that did not exist in the codebase. This caused modern browsers to render active background components as entirely flat, static layers, breaking the intended visual design.

## Testing

- [ ] Not tested (explain why)
- [x] Manually tested
- [ ] Added/updated automated tests

### Testing details:
The component was rendered locally. Verified that the CSS engine registers the translation states (`translateY(-20px)`) smoothly across the infinite loop cycle without syntax failures or layout shifting.