### PR TITLE
fix: update stale PESU Hub branding to PESiMENs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,8 +7,8 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1e40af" />
-    <meta name="description" content="PESU Hub - Campus super-app for PES University students" />
-    <title>PESimens</title>
+    <meta name="description" content="PESiMENs - Campus super-app for PES University students" />
+    <title>PESiMENs</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pesu-hub-frontend",
+  "name": "pesimens-frontend",
   "version": "1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Summary**
Updated outdated branding references from "PESU Hub" to "PESiMENs".

**Changes Made**
* Updated the application title and meta description in `frontend/index.html`
* Updated the package name in `frontend/package.json`

**Result**
The project now consistently reflects the current product name.

Closes #6
