### PR TITLE
docs: populate HISTORICAL_CHANGELOG.md with milestone summaries

### DIFF
--- a/docs/HISTORICAL_CHANGELOG.md
+++ b/docs/HISTORICAL_CHANGELOG.md
@@ -2,7 +2,38 @@
 
 This document summarizes high-level milestones that are safe to share publicly. Detailed backend and infrastructure history is maintained in the private repository.
 
-## Highlights (pre-May 2026)
+## 2026
+
+### GSSoC 2026 Public Launch
+- Opened the public repository to GirlScript Summer of Code 2026 contributors.
+- Added beginner-friendly issues, contribution labels, and onboarding resources.
+- Recognized contributors in the in-app About Us section.
+
+### Public Repository Expansion
+- Published contribution guidelines, code of conduct, security policy, and project status documentation.
+- Added beginner task references and clearer development workflows.
+- Documented the separation between the public frontend repository and the private backend infrastructure.
+
+### Branding Refresh
+- Updated the product identity from PESU Hub to PESiMENs.
+- Aligned metadata, documentation, and public-facing assets with the new branding.
+
+### UI and Landing Page Improvements
+- Continued enhancements to landing page responsiveness and visual consistency.
+- Added accessibility, spacing, and typography refinements.
+- Expanded reusable frontend components and layouts.
+
+### Documentation and Onboarding Improvements
+- Expanded setup guides, troubleshooting notes, and contributor resources.
+- Improved quick-start instructions and project structure references.
+- Added a historical changelog to help contributors understand the project's evolution.
+
+### Performance and Reliability Enhancements
+- Improved frontend usability, loading states, and error handling.
+- Added development and testing utilities.
+- Continued optimization of the public-facing application experience.
+
+## Highlights (Pre-2026)
 
 - Major UI, product, and documentation improvements were completed across multiple releases.
 - Security and reliability reviews were performed, with sensitive details kept private.


### PR DESCRIPTION
**Summary**

Expanded `HISTORICAL_CHANGELOG.md` with public milestone summaries documenting major project developments.

**Changes** Made

* Added GSSoC 2026 public launch milestones.
* Documented branding refresh from PESU Hub to PESiMENs.
* Added UI, onboarding, documentation, and performance milestones.
* Preserved a concise pre-2026 summary section.

**Benefit**

Provides contributors and visitors with a clearer understanding of the project's public evolution.

Closes #14
