### PR TITLE
feat: add reusable UI component stubs in components/common (closes #16)

### DIFF
--- a/frontend/src/components/common/Badge.tsx
+++ b/frontend/src/components/common/Badge.tsx
@@ -1,0 +1,27 @@
+interface BadgeProps {
+  label: string
+  variant?: 'default' | 'success' | 'warning' | 'danger' | 'info'
+  className?: string
+}
+
+/**
+ * Reusable badge component for status labels and tags.
+ * Usage: <Badge label="Active" variant="success" />
+ */
+export function Badge({ label, variant = 'default', className = '' }: BadgeProps) {
+  const variantClasses = {
+    default: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+    success: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+    warning: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
+    danger: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    info: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300',
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${variantClasses[variant]} ${className}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,58 @@
+interface ConfirmModalProps {
+  isOpen: boolean
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'default'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * Reusable confirmation modal component.
+ * Usage: <ConfirmModal isOpen={true} title="Delete?" message="This cannot be undone." onConfirm={handleDelete} onCancel={handleCancel} />
+ */
+export function ConfirmModal({
+  isOpen,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-sm p-6">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+          {title}
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+          {message}
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`px-4 py-2 text-sm font-medium text-white rounded-lg ${
+              variant === 'danger'
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-indigo-600 hover:bg-indigo-700'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -1,0 +1,35 @@
+interface EmptyStateProps {
+  icon?: React.ReactNode
+  title: string
+  description?: string
+  action?: React.ReactNode
+}
+
+/**
+ * Reusable empty state component for when there's no content to show.
+ * Usage: <EmptyState title="No results" description="Try a different search." />
+ */
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+      {icon && (
+        <div className="mb-4 text-gray-300 dark:text-gray-600">
+          {icon}
+        </div>
+      )}
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+        {title}
+      </h3>
+      {description && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+          {description}
+        </p>
+      )}
+      {action && (
+        <div className="mt-4">
+          {action}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/common/Spinner.tsx
+++ b/frontend/src/components/common/Spinner.tsx
@@ -1,0 +1,24 @@
+interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+/**
+ * Reusable loading spinner component.
+ * Usage: <Spinner size="md" />
+ */
+export function Spinner({ size = 'md', className = '' }: SpinnerProps) {
+  const sizeClasses = {
+    sm: 'h-4 w-4 border-2',
+    md: 'h-8 w-8 border-2',
+    lg: 'h-12 w-12 border-4',
+  }
+
+  return (
+    <div
+      className={`rounded-full border-indigo-600 border-t-transparent animate-spin ${sizeClasses[size]} ${className}`}
+      role="status"
+      aria-label="Loading"
+    />
+  )
+}


### PR DESCRIPTION
Closes #16

Added 4 reusable UI component stubs in frontend/src/components/common/

Changes made:
- Spinner.tsx — loading spinner with sm/md/lg size variants
- EmptyState.tsx — empty state with icon, title, description and action slot
- Badge.tsx — status badge with default/success/warning/danger/info variants
- ConfirmModal.tsx — confirmation modal with confirm/cancel actions and danger variant

All components:
- Follow existing code style and naming conventions
- Support dark mode via Tailwind dark: variants
- Include JSDoc comments explaining usage
- Are typed with TypeScript interfaces
