### PR TITLE
fix: update PESiMENs branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,8 +7,8 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1e40af" />
-    <meta name="description" content="PESU Hub - Campus super-app for PES University students" />
-    <title>PESimens</title>
+    <meta name="description" content="PESiMENs - Campus super-app for PES University students" />
+    <title>PESiMENs</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pesu-hub-frontend",
+  "name": "pesimens-frontend",
   "version": "1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Closes #6

## Summary
Updated stale PESU Hub branding to the current PESiMENs product name.

## What changed
- Updated `frontend/index.html` meta description from PESU Hub to PESiMENs
- Updated `frontend/index.html` page title to PESiMENs
- Renamed frontend package from `pesu-hub-frontend` to `pesimens-frontend`

## Testing
- Confirmed `frontend/package.json` parses correctly
- Ran `git diff --check`