### PR TITLE
fix: standardize material URL resolution order

### DIFF
--- a/frontend/src/pages/PYQsPage.tsx
+++ b/frontend/src/pages/PYQsPage.tsx
@@ -423,7 +423,7 @@ function FilterPanel({
           {!materialsLoading && materials.length > 0 && (
             <div className="mt-2 space-y-2">
               {materials.slice(0, 4).map((item) => {
-                const url = item.signed_url || item.file_path || item.file_url || ''
+                const url = item.signed_url || item.file_url || item.file_path || ''
                 const fileName = item.file_name || `${item.title}.pdf`
                 const status = toDisplayStatus(item.processing_status)
                 const extractionMethod = item.extraction_method || 'unknown'


### PR DESCRIPTION
## Summary

Fixes #58

This PR standardizes material URL resolution in `PYQsPage` to match the behavior already implemented in `StudyPage`.

## Changes Made

Updated the URL fallback order used when opening uploaded materials.

**Before**

```ts
const url = item.signed_url || item.file_path || item.file_url || ''
```

**After**

```ts
const url = item.signed_url || item.file_url || item.file_path || ''
```

## Reason for the Change

While reviewing the materials flow, I noticed that `PYQsPage` and `StudyPage` were resolving URLs differently for the same material object.

When a `signed_url` was not available:

* `StudyPage` prioritized `file_url`
* `PYQsPage` prioritized `file_path`

This inconsistency could cause the same material to resolve to different URLs depending on which page the user accessed it from.

By aligning the fallback order with `StudyPage`, the application now follows a consistent approach and prioritizes the publicly accessible URL before falling back to the storage path.

## Validation

* Verified that the URL resolution logic now matches across both pages.
* Kept the change scoped to the issue without modifying any unrelated functionality.

## Additional Note

The issue discussion mentioned opening the PR against the `dev` branch. However, the repository currently exposes only the `main` branch, so this PR has been opened against `main`.
