### PR TITLE
Add automated labeling and assignment workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,55 @@
+name: Auto-assign PRs and issues
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+
+            if (context.payload.pull_request) {
+              const pr = context.payload.pull_request;
+              if (pr.user.login !== context.repo.owner) {
+                await github.rest.issues.addAssignees({ ...repo, issue_number: pr.number, assignees: [pr.user.login] });
+              }
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({ ...repo, issue_number: pr.number });
+              if (!labels.find(l => l.name === 'gssoc:approved')) {
+                await github.rest.issues.addLabels({ ...repo, issue_number: pr.number, labels: ['gssoc:approved'] });
+              }
+              await github.rest.issues.createComment({ ...repo, issue_number: pr.number, body: 'Welcome! Your PR has been auto-assigned. A maintainer will review it shortly.' });
+            }
+
+            if (context.payload.issue && !context.payload.comment) {
+              const body = context.payload.issue.body || '';
+              const title = context.payload.issue.title || '';
+              const assignTriggers = ['i would like to work', 'assign me', '/assign'];
+              if (assignTriggers.some(t => body.toLowerCase().includes(t) || title.toLowerCase().includes(t))) {
+                await github.rest.issues.addAssignees({ ...repo, issue_number: context.payload.issue.number, assignees: [context.payload.issue.user.login] });
+              }
+            }
+
+            if (context.payload.comment) {
+              const comment = context.payload.comment;
+              const assignTriggers = ['i would like to work', 'assign me', '/assign'];
+              if (assignTriggers.some(t => comment.body.toLowerCase().includes(t))) {
+                const { data: issue } = await github.rest.issues.get({ ...repo, issue_number: context.payload.issue.number });
+                if (!issue.assignee) {
+                  await github.rest.issues.addAssignees({ ...repo, issue_number: context.payload.issue.number, assignees: [comment.user.login] });
+                }
+              }
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,54 @@
+name: Auto-label issues and PRs
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+
+            if (context.payload.issue) {
+              const body = (context.payload.issue.body || '').toLowerCase();
+              const title = (context.payload.issue.title || '').toLowerCase();
+
+              const labelMap = [
+                { keywords: ['bug', 'error', 'issue', 'broken', 'fix'], label: 'bug' },
+                { keywords: ['feature', 'enhancement', 'feat', 'improvement'], label: 'enhancement' },
+                { keywords: ['docs', 'documentation', 'readme'], label: 'documentation' },
+                { keywords: ['question', 'help'], label: 'question' },
+                { keywords: ['security', 'vulnerability', 'xss', 'injection'], label: 'security' },
+              ];
+
+              const toAdd = ['gssoc'];
+              for (const entry of labelMap) {
+                if (entry.keywords.some(k => title.includes(k) || body.includes(k))) {
+                  toAdd.push(entry.label);
+                  break;
+                }
+              }
+              await github.rest.issues.addLabels({ ...repo, issue_number: context.payload.issue.number, labels: toAdd });
+            }
+
+            if (context.payload.pull_request) {
+              const pr = context.payload.pull_request;
+              const additions = pr.additions || 0;
+
+              let difficulty = 'level1';
+              if (additions > 100) difficulty = 'level3';
+              else if (additions > 30) difficulty = 'level2';
+
+              await github.rest.issues.addLabels({ ...repo, issue_number: pr.number, labels: ['gssoc', difficulty] });
+            }


### PR DESCRIPTION
## What
Add automated GitHub Actions workflows for issue/PR assignment, labeling, and triage.

## Root cause
The project lacks automation for assigning PRs/issues to contributors, labeling by content and difficulty, and triaging incoming issues.

## Changes
- **auto-assign.yml**: Auto-assigns PRs to authors, assigns issues to commenters with trigger phrases (`/assign`, `I would like to work`), applies `gssoc:approved` label, and posts welcome comments
- **auto-label.yml**: Auto-labels issues by content keywords (bug/enhancement/docs/security), labels PRs by difficulty (level1/level2/level3) based on change size, and applies `gssoc` label

## Verification
1. Open a new issue → auto-labeled with `gssoc` + content-based label
2. Comment `/assign` on an issue → auto-assigned
3. Open a PR → auto-assigned to author, `gssoc:approved` label applied, welcome comment posted

## CI failures
N/A - workflow configuration only.

## Before
All assignment and labeling done manually by maintainers.

## After
Automated assignment, labeling, and triage via GitHub Actions.

Closes #72