### PR TITLE
Fix #79: Add Campus and Mentors links to mobile bottom navigation

### DIFF
--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -17,6 +17,8 @@ const moreSheetItems = [
   { to: '/timetable', emoji: '🗓', label: 'Timetable' },
   { to: '/notes', emoji: '📝', label: 'Notes' },
   { to: '/marketplace', emoji: '🛒', label: 'Marketplace' },
+  { to: '/campus', emoji: '🏫', label: 'Campus' },
+  { to: '/mentors', emoji: '🎓', label: 'Mentors' },
   { to: '/contact', emoji: '🛟', label: 'Report/Contact' },
   { to: '/messages', emoji: '💬', label: 'Messages' },
   { to: '/people', emoji: '👥', label: 'People' },


### PR DESCRIPTION
# Summary

- [X] I linked the issue this PR addresses
- [X] I targeted `dev` as the base branch unless instructed otherwise
- [X] I kept the change scoped to one issue
- [ ] I added screenshots or recordings for UI changes
- [ ] I added testing notes

## What changed

## Description
Adding the missing **Campus** and **Mentors** routes to the mobile bottom navigation's "More" drawer. 

Previously, these links were accessible on the desktop sidebar but missing from the mobile experience, which created an inconsistency in feature parity between devices.

## Changes Made
- Updated `moreSheetItems` in `frontend/src/components/layout/BottomNav.tsx` to include entries for the `/campus` and `/mentors` pages.


## Related Issue
Close #79
