### PR TITLE
feat: add skeleton loading screens for feeds

### DIFF
--- a/frontend/src/components/pyqs/PYQFeed.tsx
+++ b/frontend/src/components/pyqs/PYQFeed.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { PYQCard, type PYQ } from './PYQCard'
+import { PYQSkeleton } from '../ui/skeleton'
 import { apiFetch } from '@/lib/api'
 import { usePYQRealtime } from '@/hooks/usePYQRealtime'
 
@@ -72,12 +73,9 @@ export function PYQFeed({ filters = {}, canDeletePyq = false, onDeletePyq, delet
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="space-y-0">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-32 rounded-lg border border-[#2a2a2a] bg-gradient-to-br from-[#1a1a1a] to-[#141414] animate-pulse"
-          />
+          <PYQSkeleton key={i} />
         ))}
       </div>
     )
@@ -117,12 +115,9 @@ export function PYQFeed({ filters = {}, canDeletePyq = false, onDeletePyq, delet
       <div ref={sentinelRef} className="h-4" />
 
       {isFetchingNextPage && (
-        <div className="space-y-3">
+        <div className="space-y-0 mt-2">
           {Array.from({ length: 2 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-32 rounded-lg border border-[#2a2a2a] bg-gradient-to-br from-[#1a1a1a] to-[#141414] animate-pulse"
-            />
+            <PYQSkeleton key={i} />
           ))}
         </div>
       )}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -24,13 +24,121 @@ export function Skeleton({ className, variant = 'rectangle', ...props }: Skeleto
 
 export function SkeletonCard() {
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 space-y-3">
-      <Skeleton className="h-40 w-full" />
-      <Skeleton variant="text" className="w-3/4" />
-      <Skeleton variant="text" className="w-1/2" />
-      <div className="flex gap-2">
-        <Skeleton variant="text" className="w-16 h-6 rounded-full" />
-        <Skeleton variant="text" className="w-16 h-6 rounded-full" />
+    <div className="group rounded-xl border border-[#2a2a2a] dark:border-gray-700 bg-[#1a1a1a] dark:bg-gray-800 overflow-hidden flex flex-col">
+      <div className="aspect-video w-full bg-[#222222] dark:bg-gray-700 animate-pulse" />
+      <div className="p-4 flex flex-col gap-3 flex-1">
+        <div className="flex gap-2">
+          <div className="h-5 w-16 bg-[#2a2a2a] dark:bg-gray-700 rounded-full animate-pulse" />
+        </div>
+        <div className="h-5 w-3/4 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+        <div className="flex flex-col gap-2 mt-1">
+          <div className="h-3 w-1/2 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-3 w-2/3 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <div className="mt-auto pt-4 flex items-center justify-between gap-2">
+          <div className="h-4 w-20 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-8 w-24 bg-[#2a2a2a] dark:bg-gray-700 rounded-lg animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PYQSkeleton() {
+  return (
+    <div className="mb-2 flex overflow-hidden rounded-[12px] border border-[#2a2a2a]">
+      <div className="w-[40px] shrink-0 border-r border-[#2a2a2a] bg-[#111111]">
+        <div className="flex min-h-[124px] flex-col items-center justify-center gap-2 py-2">
+          <div className="h-3 w-3 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-3 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 bg-[#1a1a1a] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-4 w-14 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-3 w-8 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 space-y-2">
+          <div className="h-4 w-3/4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-1/2 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 flex gap-2">
+          <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+        </div>
+        <div className="my-3 h-px bg-[#2a2a2a]" />
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex gap-3">
+            <div className="h-3 w-16 bg-[#2a2a2a] rounded animate-pulse" />
+            <div className="h-3 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 bg-[#2a2a2a] rounded-full animate-pulse" />
+            <div className="h-3 w-16 bg-[#2a2a2a] rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ConfessionSkeleton() {
+  return (
+    <div className="mb-4 overflow-hidden rounded-2xl border border-[#242424] bg-[#121212] flex">
+      <div className="w-[42px] shrink-0 border-r border-[#232323] bg-[#101010]">
+        <div className="flex min-h-[128px] flex-col items-center justify-center gap-2 py-2">
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-5 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 bg-[#171717] px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-3 w-20 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 space-y-2">
+          <div className="h-4 w-[90%] bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-[85%] bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-[60%] bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-4 flex gap-3 border-t border-[#242424] pt-3">
+          <div className="h-5 w-10 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-5 w-10 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-5 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PersonSkeleton() {
+  return (
+    <div className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+      <div className="flex items-center gap-3">
+        <div className="h-14 w-14 rounded-full bg-[#2a2a2a] animate-pulse shrink-0" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="h-4 w-3/4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-1/2 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="mt-3">
+        <div className="h-3 w-2/3 bg-[#2a2a2a] rounded animate-pulse" />
+      </div>
+      <div className="mt-3 flex gap-2">
+        <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+        <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+      </div>
+      <div className="mt-4 flex items-center justify-between">
+        <div className="h-5 w-14 bg-[#2a2a2a] rounded animate-pulse" />
+        <div className="h-4 w-20 bg-[#2a2a2a] rounded-full animate-pulse" />
+      </div>
+      <div className="mt-4 flex gap-2">
+        <div className="h-8 w-24 bg-[#2a2a2a] rounded-lg animate-pulse" />
+        <div className="h-8 w-24 bg-[#2a2a2a] rounded-lg animate-pulse" />
       </div>
     </div>
   )

--- a/frontend/src/pages/ConfessionsPage.tsx
+++ b/frontend/src/pages/ConfessionsPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { ApiError, apiFetch } from '@/lib/api'
 import { cn, formatDistanceToNow } from '@/lib/utils'
 import { useToast } from '@/components/ui/use-toast'
+import { ConfessionSkeleton } from '@/components/ui/skeleton'
 import { useConfessionsRealtime } from '@/hooks/useConfessionsRealtime'
 import { useAuthStore } from '@/store/auth'
 
@@ -847,14 +848,9 @@ export default function ConfessionsPage() {
 
             <div>
               {confessionsQuery.isLoading && (
-                <div className="space-y-2">
+                <div className="space-y-0">
                   {safeArray(Array.from({ length: 3 })).map((_, idx) => (
-                    <div key={idx} className="overflow-hidden rounded-[12px] border border-[#2a2a2a]">
-                      <div className="flex h-[140px]">
-                        <div className="w-[44px] border-r border-[#2a2a2a] bg-[#111111]" />
-                        <div className="flex-1 animate-pulse bg-[#1a1a1a]" />
-                      </div>
-                    </div>
+                    <ConfessionSkeleton key={idx} />
                   ))}
                 </div>
               )}
@@ -1193,9 +1189,9 @@ export default function ConfessionsPage() {
               <div ref={loadMoreRef} className="h-4" />
 
               {confessionsQuery.isFetchingNextPage && (
-                <div className="space-y-2">
+                <div className="space-y-0 mt-4">
                   {safeArray(Array.from({ length: 2 })).map((_, idx) => (
-                    <div key={idx} className="h-24 animate-pulse rounded-xl border border-[#2a2a2a] bg-[#1a1a1a]" />
+                    <ConfessionSkeleton key={idx} />
                   ))}
                 </div>
               )}

--- a/frontend/src/pages/PeoplePage.tsx
+++ b/frontend/src/pages/PeoplePage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { UserCheck, Users } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { UserAvatar } from '@/components/ui/avatar'
+import { PersonSkeleton } from '@/components/ui/skeleton'
 import { KarmaBadge } from '@/components/common/KarmaBadge'
 import { FollowButton } from '@/components/common/FollowButton'
 import { Link, useSearchParams } from 'react-router-dom'
@@ -129,7 +130,10 @@ export default function PeoplePage() {
             </div>
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {people.map(person => (
+              {query.isLoading ? (
+                Array.from({ length: 6 }).map((_, i) => <PersonSkeleton key={i} />)
+              ) : (
+                people.map(person => (
                 <div key={person.id} className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
                   <div className="flex items-center gap-3">
                     <UserAvatar name={person.display_name} avatarUrl={person.avatar_url} className="h-14 w-14" />
@@ -165,10 +169,10 @@ export default function PeoplePage() {
                     )}
                   </div>
                 </div>
-              ))}
+              )))}
             </div>
 
-            {people.length === 0 && (
+            {!query.isLoading && people.length === 0 && (
               <p className="py-12 text-center text-sm text-white/60">No people found for current filters.</p>
             )}
           </>


### PR DESCRIPTION
Added feed-specific skeleton loaders (PYQ, Confession, Event, People) using animate-pulse. Replaced basic loading placeholders with skeletons matching the original card dimensions to prevent layout shifts.

**Issue** : #69 
# Summary


- [x] I linked the issue this PR addresses
- [x] I targeted `dev` as the base branch unless instructed otherwise
- [x] I kept the change scoped to one issue
- [ ] I added screenshots or recordings for UI changes
- [x] I added testing notes

## What changed
- Created specific skeleton loading components (`PYQSkeleton`, `ConfessionSkeleton`, `PersonSkeleton`) in `src/components/ui/skeleton.tsx`.
- Updated the existing `SkeletonCard` to match the exact dimensions and layout of `EventCard`.
- Integrated these new skeletons into the initial loading and infinite scroll fetching states across `PYQFeed.tsx`, `ConfessionsPage.tsx`, `EventsPage.tsx`, and `PeoplePage.tsx`.

## Why this change is needed
Previously, major feed pages (PYQ, Confessions, Events, People Directory) displayed generic blank areas or poorly-sized boxes during data fetching. This created jarring layout shifts when the real content suddenly rendered. By using skeletons that match the exact card dimensions of each feed, we prevent layout shifting and provide a much smoother, polished user experience while data is loading.

## Testing

- [ ] Not tested (explain why)
- [x] Manually tested
- [ ] Added/updated automated tests

**Testing Notes**:
Verified that the skeleton components utilize Tailwind's `animate-pulse` correctly and that they seamlessly match the structure (padding, margins, avatar placements, icon placements) of the actual data cards across all 4 feeds.

## Screenshots (if applicable)
*(Feel free to add any screenshots or screen recordings of the smooth loading state here!)*
