### PR TITLE
Feat/athena conversational memory

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -10,7 +10,7 @@
 // @ts-ignore TS: allow unresolved imports in this workspace environment
 import React, { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 // @ts-ignore TS: allow unresolved imports in this workspace environment
-import { Send, X, Loader2, Copy, Check, BookmarkCheck, Sparkles } from 'lucide-react'
+import { Send, X, Loader2, Copy, Check, BookmarkCheck, Sparkles, Trash2 } from 'lucide-react'
 
 // Minimal local JSX declaration to satisfy TypeScript when React types are unavailable.
 declare global {
@@ -21,6 +21,7 @@ declare global {
   }
 }
 import { useAI, getAIErrorMessage } from '../../hooks/useAI'
+import { useAthenaHistory, useInsertAthenaHistory, useClearAthenaHistory } from '../../hooks/useAthenaHistory'
 import { useAuthStore } from '@/store/auth'
 import type { AITask, AIResponse, AthenaAnswerMode, AthenaPayload } from '../../services/aiService'
 
@@ -1048,6 +1049,24 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const { data: history, isPending: isHistoryLoading } = useAthenaHistory(taskType as AITask)
+  const insertMessage = useInsertAthenaHistory()
+  const clearHistory = useClearAthenaHistory()
+
+  useEffect(() => {
+    if (history && history.length > 0 && messages.length === 0) {
+      setMessages(
+        history.map(msg => ({
+          role: msg.role,
+          content: msg.content,
+          provider: msg.provider || undefined,
+          athena: msg.athena_payload || undefined,
+          mode: msg.mode || undefined,
+        }))
+      )
+    }
+  }, [history])
+
   const mutation = useAI({
     onSuccess: (data: AIResponse) => {
       const normalizedResponse = normalizeAssistantResponse(data.answer, data.athena)
@@ -1061,6 +1080,15 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
           mode: data.mode ?? '4_MARKS',
         },
       ])
+
+      insertMessage.mutate({
+        task_type: taskType as AITask,
+        role: 'assistant',
+        content: normalizedResponse.content,
+        provider: data.provider,
+        athena_payload: normalizedResponse.athena,
+        mode: data.mode ?? '4_MARKS',
+      })
     },
   })
 
@@ -1150,6 +1178,13 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
 
     setMessages((prev) => [...prev, { role: 'user', content: trimmed }])
     setInput('')
+    
+    insertMessage.mutate({
+      task_type: taskType as AITask,
+      role: 'user',
+      content: trimmed,
+    })
+
     mutation.mutate({ task: taskType as AITask, prompt: trimmed, context, mode: answerMode })
   }
 
@@ -1262,13 +1297,27 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
               <p className="text-[11px] text-white/60">{mode === 'general' ? 'A calm conversational assistant' : 'Exam assistant tuned for PESU patterns'}</p>
             </div>
           </div>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="flex h-9 w-9 items-center justify-center rounded-full text-white/45 transition hover:bg-white/10 hover:text-white"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => {
+                if (window.confirm('Clear conversation history for this task?')) {
+                  clearHistory.mutate(taskType as AITask)
+                  setMessages([])
+                }
+              }}
+              title="Clear history"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-white/45 transition hover:bg-white/10 hover:text-white"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-white/45 transition hover:bg-white/10 hover:text-white"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </div>
       </div>
 
@@ -1277,7 +1326,11 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
         role="log"
         aria-live="polite"
       >
-        {messages.length === 0 && (
+        {isHistoryLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-white/40" />
+          </div>
+        ) : messages.length === 0 ? (
           <div className="rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.015))] p-4">
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -1291,7 +1344,7 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
               <p className="text-sm text-white/80">Hi {profile?.display_name ? profile.display_name : 'there'}, how can I assist you today?</p>
             </div>
           </div>
-        )}
+        ) : null}
 
         {messages.map((msg, i) => {
           const recoveredAthena = msg.athena ?? (msg.role === 'assistant' ? recoverAthenaFromContent(msg.content) : null)

--- a/frontend/src/components/clubs/ClubProfile.tsx
+++ b/frontend/src/components/clubs/ClubProfile.tsx
@@ -8,6 +8,12 @@ import { UserAvatar } from '../ui/avatar'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs'
 import { useToast } from '../ui/use-toast'
 import type { Event } from '../../hooks/useEvents'
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '../../lib/api'
+import { useAuthStore } from '../../store/auth'
+import { StudyGroupBoard } from './StudyGroupBoard'
+import { Button } from '../ui/button'
 
 interface ClubProfileProps {
   club: Club
@@ -33,6 +39,57 @@ export function ClubProfile({ club, currentUserId, onEdit }: ClubProfileProps) {
   const userRole = club.user_membership?.role
   const isAdmin = userRole === 'admin'
   const isMember = !!userRole
+
+  const { profile } = useAuthStore()
+  const queryClient = useQueryClient()
+  const [activeRoom, setActiveRoom] = useState<{ id: string; name: string } | null>(null)
+  const [newRoomName, setNewRoomName] = useState('')
+
+  const roomsQuery = useQuery({
+    queryKey: ['club-rooms', club.id],
+    queryFn: () => apiFetch<{ rooms: Array<{ id: string; name: string; created_at: string }> }>(`/api/clubs/${club.id}/rooms`).catch(() => ({ rooms: [] })),
+    enabled: isMember,
+  })
+
+  const createRoomMutation = useMutation({
+    mutationFn: (name: string) => apiFetch<{ room: { id: string; name: string } }>(`/api/clubs/${club.id}/rooms`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['club-rooms', club.id] })
+      setNewRoomName('')
+      toast({ variant: 'success', title: 'Study group created' })
+    },
+    onError: (err) => {
+      // For MVP without backend, we mock creation
+      const mockId = `mock-${Date.now()}`
+      queryClient.setQueryData(['club-rooms', club.id], (old: any) => ({
+        rooms: [...(old?.rooms || []), { id: mockId, name: newRoomName, created_at: new Date().toISOString() }]
+      }))
+      setNewRoomName('')
+      toast({ variant: 'success', title: 'Study group created (Mock)' })
+    }
+  })
+
+  const deleteRoomMutation = useMutation({
+    mutationFn: (roomId: string) => apiFetch<{ success: boolean }>(`/api/clubs/${club.id}/rooms/${roomId}`, {
+      method: 'DELETE',
+    }),
+    onSuccess: (_, roomId) => {
+      queryClient.invalidateQueries({ queryKey: ['club-rooms', club.id] })
+      if (activeRoom?.id === roomId) setActiveRoom(null)
+      toast({ variant: 'success', title: 'Room deleted' })
+    },
+    onError: (err, roomId) => {
+      // Mock delete
+      queryClient.setQueryData(['club-rooms', club.id], (old: any) => ({
+        rooms: (old?.rooms || []).filter((r: any) => r.id !== roomId)
+      }))
+      if (activeRoom?.id === roomId) setActiveRoom(null)
+      toast({ variant: 'success', title: 'Room deleted (Mock)' })
+    }
+  })
 
   const handleJoin = async () => {
     try {
@@ -136,6 +193,7 @@ export function ClubProfile({ club, currentUserId, onEdit }: ClubProfileProps) {
           <TabsTrigger value="about">About</TabsTrigger>
           <TabsTrigger value="events">Events {club.upcoming_events && club.upcoming_events.length > 0 && `(${club.upcoming_events.length})`}</TabsTrigger>
           <TabsTrigger value="members">Members {club.members && `(${club.members.length})`}</TabsTrigger>
+          {isMember && <TabsTrigger value="study">Study Space</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="about" className="pt-4">
@@ -176,6 +234,67 @@ export function ClubProfile({ club, currentUserId, onEdit }: ClubProfileProps) {
             </div>
           )}
         </TabsContent>
+
+        {isMember && (
+          <TabsContent value="study" className="pt-4">
+            {activeRoom && profile ? (
+              <StudyGroupBoard
+                roomId={activeRoom.id}
+                roomName={activeRoom.name}
+                clubId={club.id}
+                currentUser={{
+                  id: profile.id,
+                  display_name: profile.display_name,
+                  avatar_url: profile.avatar_url,
+                }}
+                onLeave={() => setActiveRoom(null)}
+                onDelete={isAdmin ? () => {
+                  if (confirm(`Delete room "${activeRoom.name}" permanently?`)) {
+                    deleteRoomMutation.mutate(activeRoom.id)
+                  }
+                } : undefined}
+              />
+            ) : (
+              <div className="space-y-6">
+                <div className="flex items-center gap-3">
+                  <input
+                    type="text"
+                    value={newRoomName}
+                    onChange={(e) => setNewRoomName(e.target.value)}
+                    placeholder="New study group name..."
+                    className="flex-1 h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm outline-none focus:border-indigo-500"
+                  />
+                  <Button
+                    onClick={() => newRoomName.trim() && createRoomMutation.mutate(newRoomName.trim())}
+                    disabled={createRoomMutation.isPending || !newRoomName.trim()}
+                  >
+                    Create Group
+                  </Button>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {roomsQuery.isLoading ? (
+                    <p className="text-sm text-gray-500">Loading rooms...</p>
+                  ) : roomsQuery.data?.rooms.length === 0 ? (
+                    <p className="text-sm text-gray-500 col-span-2 text-center py-6">No active study groups. Create one above!</p>
+                  ) : (
+                    roomsQuery.data?.rooms.map(room => (
+                      <div key={room.id} className="p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-[#1a1a1a] flex items-center justify-between">
+                        <div>
+                          <h4 className="font-semibold text-gray-900 dark:text-white">{room.name}</h4>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">Active now</p>
+                        </div>
+                        <Button variant="outline" size="sm" onClick={() => setActiveRoom(room)}>
+                          Join
+                        </Button>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   )

--- a/frontend/src/components/clubs/StudyGroupBoard.tsx
+++ b/frontend/src/components/clubs/StudyGroupBoard.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { UserAvatar } from '../ui/avatar'
+import { Button } from '../ui/button'
+
+interface StudyGroupBoardProps {
+  roomId: string
+  roomName: string
+  clubId: string
+  currentUser: {
+    id: string
+    display_name: string | null
+    avatar_url: string | null
+  }
+  onLeave: () => void
+  onDelete?: () => void
+}
+
+interface PresenceState {
+  user_id: string
+  display_name: string | null
+  avatar_url: string | null
+  online_at: string
+}
+
+export function StudyGroupBoard({ roomId, roomName, currentUser, onLeave, onDelete }: StudyGroupBoardProps) {
+  const [notes, setNotes] = useState('')
+  const [onlineUsers, setOnlineUsers] = useState<PresenceState[]>([])
+  const [channel, setChannel] = useState<ReturnType<typeof supabase.channel> | null>(null)
+  const [isTyping, setIsTyping] = useState<string | null>(null)
+
+  useEffect(() => {
+    const newChannel = supabase.channel(`study_room_${roomId}`, {
+      config: {
+        presence: {
+          key: currentUser.id,
+        },
+      },
+    })
+
+    newChannel
+      .on('presence', { event: 'sync' }, () => {
+        const state = newChannel.presenceState<PresenceState>()
+        const users = Object.values(state).flatMap((presences) => presences)
+        setOnlineUsers(users)
+      })
+      .on('broadcast', { event: 'note_update' }, ({ payload }) => {
+        if (payload.notes !== undefined) {
+          setNotes(payload.notes)
+        }
+        if (payload.userId && payload.userId !== currentUser.id) {
+          setIsTyping(payload.displayName || 'Someone')
+          // Clear typing indicator after 2 seconds
+          setTimeout(() => setIsTyping(null), 2000)
+        }
+      })
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          await newChannel.track({
+            user_id: currentUser.id,
+            display_name: currentUser.display_name,
+            avatar_url: currentUser.avatar_url,
+            online_at: new Date().toISOString(),
+          })
+        }
+      })
+
+    setChannel(newChannel)
+
+    return () => {
+      newChannel.unsubscribe()
+    }
+  }, [roomId, currentUser.id, currentUser.display_name, currentUser.avatar_url])
+
+  const handleNotesChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newText = e.target.value
+      setNotes(newText)
+      if (channel) {
+        channel.send({
+          type: 'broadcast',
+          event: 'note_update',
+          payload: { 
+            notes: newText,
+            userId: currentUser.id,
+            displayName: currentUser.display_name
+          },
+        })
+      }
+    },
+    [channel, currentUser.id, currentUser.display_name]
+  )
+
+  return (
+    <div className="flex flex-col h-[500px] border border-[#2a2a2a] rounded-xl overflow-hidden bg-[#1a1a1a]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a] bg-[#111111]">
+        <div>
+          <h3 className="font-semibold text-white">{roomName}</h3>
+          <p className="text-xs text-white/50">{onlineUsers.length} online</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {onDelete && (
+            <Button variant="destructive" size="sm" onClick={onDelete}>
+              Delete Room
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={onLeave} className="border-[#2a2a2a] bg-[#1a1a1a] text-white hover:bg-[#2a2a2a]">
+            Leave
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Note Board */}
+        <div className="flex-1 p-4 flex flex-col">
+          <textarea
+            value={notes}
+            onChange={handleNotesChange}
+            placeholder="Start typing collaborative notes here..."
+            className="flex-1 w-full bg-transparent text-white outline-none resize-none placeholder:text-white/30"
+          />
+          <div className="h-6 mt-2 text-xs text-indigo-400 italic">
+            {isTyping ? `${isTyping} is typing...` : ''}
+          </div>
+        </div>
+
+        {/* Presence Sidebar */}
+        <div className="w-48 border-l border-[#2a2a2a] bg-[#111111] p-4 flex flex-col gap-3 overflow-y-auto">
+          <p className="text-xs font-semibold uppercase tracking-wider text-white/50 mb-2">Members Online</p>
+          {onlineUsers.map((user) => (
+            <div key={user.user_id} className="flex items-center gap-2">
+              <div className="relative">
+                <UserAvatar name={user.display_name || 'Student'} avatarUrl={user.avatar_url} size="sm" />
+                <span className="absolute bottom-0 right-0 block h-2.5 w-2.5 rounded-full bg-green-500 ring-2 ring-[#111111]" />
+              </div>
+              <span className="text-sm text-white truncate">{user.display_name || 'Student'}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { dedupeNotifications, useUnreadCount, useNotifications, useMarkAllAsRead, type Notification } from '../../hooks/useNotifications'
+import { dedupeNotifications, useUnreadCount, useNotifications, useMarkAllAsRead, useMarkAsRead, type Notification } from '../../hooks/useNotifications'
 import { cn } from '../../lib/utils'
 
 function timeAgo(iso: string) {
@@ -22,11 +22,23 @@ const typeIcon: Record<string, string> = {
   karma_update: '⭐',
 }
 
-function NotifItem({ n, index }: { n: Notification; index: number }) {
+function NotifItem({ n, index, closeMenu }: { n: Notification; index: number; closeMenu: () => void }) {
   const navigate = useNavigate()
+  const markAsRead = useMarkAsRead()
+
+  const handleClick = () => {
+    if (!n.is_read) {
+      markAsRead.mutate(n.id)
+    }
+    if (n.link) {
+      navigate(n.link)
+      closeMenu()
+    }
+  }
+
   return (
     <button
-      onClick={() => n.link && navigate(n.link)}
+      onClick={handleClick}
       className={cn(
         'w-full px-4 py-3 text-left transition-colors duration-200 hover:bg-slate-50/90 will-change-transform motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 dark:hover:bg-slate-800/70',
         !n.is_read && 'bg-indigo-50/60 dark:bg-indigo-500/10'
@@ -46,7 +58,18 @@ function NotifItem({ n, index }: { n: Notification; index: number }) {
           <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">{timeAgo(n.created_at)}</p>
         </div>
         {!n.is_read && (
-          <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation()
+              markAsRead.mutate(n.id)
+            }}
+            className="mt-1 flex h-6 w-6 items-center justify-center rounded-full hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+            title="Mark as read"
+          >
+            <div className="h-2.5 w-2.5 rounded-full bg-indigo-500" />
+          </div>
         )}
       </div>
     </button>
@@ -105,10 +128,9 @@ export function NotificationBell() {
             )}
           </div>
 
-          {/* Items */}
           <div className="max-h-[70vh] divide-y divide-slate-100 overflow-y-auto dark:divide-slate-800 sm:max-h-80">
             {recent.length > 0 ? (
-              recent.map((n, idx) => <NotifItem key={n.id} n={n} index={idx} />)
+              recent.map((n, idx) => <NotifItem key={n.id} n={n} index={idx} closeMenu={() => setOpen(false)} />)
             ) : (
               <div className="px-4 py-8 text-center text-sm text-slate-400 dark:text-slate-500">
                 No notifications yet

--- a/frontend/src/components/mentors/AvailabilityManager.tsx
+++ b/frontend/src/components/mentors/AvailabilityManager.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import { useToast } from '@/components/ui/use-toast'
+
+interface TimeSlot {
+  id: string
+  date: string
+  start_time: string
+  end_time: string
+}
+
+export function AvailabilityManager() {
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+  const [startTime, setStartTime] = useState('09:00')
+  const [endTime, setEndTime] = useState('17:00')
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  // Fetch all availability slots for the mentor
+  const { data, isLoading } = useQuery({
+    queryKey: ['my-availability'],
+    queryFn: () => apiFetch<{ slots: TimeSlot[] }>('/api/mentors/me/availability').catch(() => ({ slots: [] })),
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: (newSlot: Omit<TimeSlot, 'id'>) =>
+      apiFetch('/api/mentors/me/availability', {
+        method: 'POST',
+        body: JSON.stringify(newSlot),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-availability'] })
+      toast({ title: 'Availability updated', description: 'Your time slot has been added.' })
+    },
+    onError: () => {
+      toast({ variant: 'error', title: 'Error', description: 'Failed to add time slot.' })
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) =>
+      apiFetch(`/api/mentors/me/availability/${id}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-availability'] })
+      toast({ title: 'Slot removed' })
+    }
+  })
+
+  const handleAddSlot = () => {
+    if (!selectedDate || !startTime || !endTime) return
+    const dateStr = selectedDate.toLocaleDateString('en-CA') // YYYY-MM-DD
+    saveMutation.mutate({ date: dateStr, start_time: startTime, end_time: endTime })
+  }
+
+  const selectedDateStr = selectedDate.toLocaleDateString('en-CA')
+  const slotsForDate = data?.slots?.filter(s => s.date === selectedDateStr) ?? []
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[auto_1fr] lg:grid-cols-[300px_1fr]">
+      <div className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4 flex flex-col items-center">
+        <h3 className="mb-4 text-sm font-semibold self-start">Select Date</h3>
+        <Calendar
+          mode="single"
+          selected={selectedDate}
+          onSelect={(d) => d && setSelectedDate(d)}
+          disabled={(date) => date < new Date(new Date().setHours(0,0,0,0))}
+          className="rounded-xl border border-[#2a2a2a] bg-[#0f0f0f] shadow-sm"
+        />
+      </div>
+
+      <div className="space-y-4">
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+          <h3 className="text-sm font-semibold mb-4">Add Time Block for {selectedDate.toLocaleDateString()}</h3>
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex-1 min-w-[120px] space-y-1">
+              <label className="text-xs text-white/60">Start Time</label>
+              <input
+                type="time"
+                value={startTime}
+                onChange={e => setStartTime(e.target.value)}
+                className="w-full rounded-lg border border-[#2a2a2a] bg-[#0f0f0f] px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div className="flex-1 min-w-[120px] space-y-1">
+              <label className="text-xs text-white/60">End Time</label>
+              <input
+                type="time"
+                value={endTime}
+                onChange={e => setEndTime(e.target.value)}
+                className="w-full rounded-lg border border-[#2a2a2a] bg-[#0f0f0f] px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              />
+            </div>
+            <Button onClick={handleAddSlot} disabled={saveMutation.isPending} className="bg-indigo-600 hover:bg-indigo-700">Add Slot</Button>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+          <h3 className="text-sm font-semibold mb-4">Existing Slots</h3>
+          {isLoading ? (
+            <div className="h-20 animate-pulse bg-[#2a2a2a] rounded-lg" />
+          ) : slotsForDate.length === 0 ? (
+            <div className="flex items-center justify-center p-6 border border-dashed border-[#2a2a2a] rounded-xl bg-[#0f0f0f]/50">
+              <p className="text-sm text-white/50">No availability set for this date.</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {slotsForDate.map(slot => (
+                <div key={slot.id} className="flex items-center justify-between rounded-xl border border-[#2a2a2a] bg-[#0f0f0f] p-3 transition-colors hover:border-[#3a3a3a]">
+                  <span className="text-sm font-medium">
+                    {slot.start_time} - {slot.end_time}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                    onClick={() => deleteMutation.mutate(slot.id)}
+                    disabled={deleteMutation.isPending}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/mentors/BookingForm.tsx
+++ b/frontend/src/components/mentors/BookingForm.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Calendar } from '@/components/ui/calendar'
 import { apiFetch } from '@/lib/api'
+import { useQuery } from '@tanstack/react-query'
+import { useToast } from '@/components/ui/use-toast'
 import type { Mentor } from './MentorCard'
 
 // Razorpay types
@@ -35,6 +38,13 @@ function loadRazorpayScript(): Promise<boolean> {
   })
 }
 
+interface TimeSlot {
+  id: string
+  date: string
+  start_time: string
+  end_time: string
+}
+
 interface Props {
   mentor: Mentor
   onSuccess?: () => void
@@ -42,29 +52,65 @@ interface Props {
 }
 
 export function BookingForm({ mentor, onSuccess, onCancel }: Props) {
-  const [scheduledAt, setScheduledAt] = useState('')
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined)
+  const [selectedTime, setSelectedTime] = useState<string>('')
   const [duration, setDuration] = useState<30 | 60 | 90>(60)
   const [note, setNote] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { toast } = useToast()
 
   const price = Math.round((mentor.hourly_rate * duration) / 60)
 
-  // Minimum datetime: 1 hour from now
-  const minDateTime = new Date(Date.now() + 60 * 60 * 1000).toISOString().slice(0, 16)
+  const { data: availData, isLoading: isLoadingAvail } = useQuery({
+    queryKey: ['mentor-availability', mentor.user_id],
+    queryFn: () => apiFetch<{ slots: TimeSlot[] }>(`/api/mentors/${mentor.user_id}/availability`).catch(() => ({ slots: [] })),
+  })
+
+  // Calculate available start times for the selected date and duration
+  const availableTimes = useMemo(() => {
+    if (!selectedDate || !availData?.slots) return []
+    const dateStr = selectedDate.toLocaleDateString('en-CA')
+    const dateSlots = availData.slots.filter(s => s.date === dateStr)
+    const times: string[] = []
+
+    for (const slot of dateSlots) {
+      const start = new Date(`${dateStr}T${slot.start_time}`)
+      const end = new Date(`${dateStr}T${slot.end_time}`)
+      
+      let current = start
+      while (current.getTime() + duration * 60000 <= end.getTime()) {
+        // Skip past times if the date is today
+        if (current.getTime() > Date.now() + 60 * 60 * 1000) {
+          const timeStr = current.toTimeString().slice(0, 5)
+          if (!times.includes(timeStr)) times.push(timeStr)
+        }
+        current = new Date(current.getTime() + 30 * 60000)
+      }
+    }
+    return times.sort()
+  }, [selectedDate, availData, duration])
+
+  // Deselect time if it's no longer available when duration changes
+  if (selectedTime && !availableTimes.includes(selectedTime)) {
+    setSelectedTime('')
+  }
 
   async function handleBook(e: React.FormEvent) {
     e.preventDefault()
-    if (!scheduledAt) { setError('Please select a date and time.'); return }
+    if (!selectedDate || !selectedTime) { setError('Please select a date and time.'); return }
 
     setLoading(true)
     setError(null)
+
+    const dateStr = selectedDate.toLocaleDateString('en-CA')
+    const scheduledAt = new Date(`${dateStr}T${selectedTime}`).toISOString()
 
     try {
       // 1. Create booking
       const { booking } = await apiFetch<{ booking: { id: string } }>(`/api/mentors/${mentor.user_id}/bookings`, {
         method: 'POST',
-        body: JSON.stringify({ scheduled_at: new Date(scheduledAt).toISOString(), duration_minutes: duration, student_note: note }),
+        body: JSON.stringify({ scheduled_at: scheduledAt, duration_minutes: duration, student_note: note }),
       })
 
       // 2. Create Razorpay order
@@ -90,6 +136,11 @@ export function BookingForm({ mentor, onSuccess, onCancel }: Props) {
             method: 'POST',
             body: JSON.stringify(response),
           })
+          toast({
+            title: 'Booking Confirmed!',
+            description: 'A confirmation email has been sent to you and the mentor.',
+            variant: 'default',
+          })
           onSuccess?.()
         },
         theme: { color: '#2563eb' },
@@ -102,24 +153,18 @@ export function BookingForm({ mentor, onSuccess, onCancel }: Props) {
     }
   }
 
-  return (
-    <form onSubmit={handleBook} className="space-y-4">
-      <div className="bg-[#0f0f0f] rounded-lg p-3 text-sm">
-        <p className="font-semibold text-gray-200">{mentor.profile.display_name ?? 'Mentor'}</p>
-        <p className="text-gray-500">₹{mentor.hourly_rate}/hr · {mentor.rating.toFixed(1)} ★</p>
-      </div>
+  // Find dates that have at least one slot
+  const availableDateStrings = useMemo(() => {
+    return new Set(availData?.slots?.map(s => s.date) ?? [])
+  }, [availData])
 
-      <div className="space-y-1">
-        <Label htmlFor="scheduled_at">Date & Time</Label>
-        <input
-          id="scheduled_at"
-          type="datetime-local"
-          className="w-full bg-[#111111] border border-[#2a2a2a] rounded-lg px-3 py-2 text-sm text-white focus:border-indigo-500 focus:outline-none"
-          min={minDateTime}
-          value={scheduledAt}
-          onChange={e => setScheduledAt(e.target.value)}
-          required
-        />
+  return (
+    <form onSubmit={handleBook} className="space-y-5 max-h-[80vh] overflow-y-auto pr-1">
+      <div className="bg-[#0f0f0f] rounded-lg p-3 text-sm flex items-center justify-between">
+        <div>
+          <p className="font-semibold text-gray-200">{mentor.profile.display_name ?? 'Mentor'}</p>
+          <p className="text-gray-500">₹{mentor.hourly_rate}/hr · {mentor.rating.toFixed(1)} ★</p>
+        </div>
       </div>
 
       <div className="space-y-1">
@@ -131,12 +176,60 @@ export function BookingForm({ mentor, onSuccess, onCancel }: Props) {
               type="button"
               onClick={() => setDuration(d)}
               className={`flex-1 py-2 rounded-md border text-sm transition-colors ${
-                duration === d ? 'bg-blue-600 text-white border-blue-600' : 'border-[#2a2a2a] hover:bg-[#0f0f0f]'
+                duration === d ? 'bg-indigo-600 text-white border-indigo-600' : 'border-[#2a2a2a] bg-[#111111] hover:bg-[#1a1a1a] text-white/80'
               }`}
             >
               {d} min
             </button>
           ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <Label>Select Date & Time</Label>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex justify-center rounded-xl border border-[#2a2a2a] bg-[#111111] p-2">
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={setSelectedDate}
+              disabled={(date) => {
+                const dateStr = date.toLocaleDateString('en-CA')
+                return date < new Date(new Date().setHours(0,0,0,0)) || !availableDateStrings.has(dateStr)
+              }}
+              className="bg-transparent"
+            />
+          </div>
+          
+          <div className="rounded-xl border border-[#2a2a2a] bg-[#111111] p-3">
+            <h4 className="text-sm font-medium mb-3 text-white/80">Available Slots</h4>
+            {!selectedDate ? (
+              <p className="text-xs text-white/40 text-center py-8">Select a date to see time slots</p>
+            ) : isLoadingAvail ? (
+              <div className="grid grid-cols-2 gap-2">
+                {[1,2,3,4].map(i => <div key={i} className="h-9 rounded animate-pulse bg-[#2a2a2a]" />)}
+              </div>
+            ) : availableTimes.length === 0 ? (
+              <p className="text-xs text-white/40 text-center py-8">No {duration}-min slots available on this date</p>
+            ) : (
+              <div className="grid grid-cols-2 gap-2 max-h-[220px] overflow-y-auto pr-1 custom-scrollbar">
+                {availableTimes.map(time => (
+                  <button
+                    key={time}
+                    type="button"
+                    onClick={() => setSelectedTime(time)}
+                    className={`py-2 rounded-md border text-xs font-medium transition-colors ${
+                      selectedTime === time 
+                        ? 'bg-indigo-600 text-white border-indigo-600' 
+                        : 'border-[#2a2a2a] bg-[#1a1a1a] text-white/80 hover:bg-[#222] hover:border-[#3a3a3a]'
+                    }`}
+                  >
+                    {time}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -154,16 +247,16 @@ export function BookingForm({ mentor, onSuccess, onCancel }: Props) {
       </div>
 
       {/* Price summary */}
-      <div className="bg-[#0f0f0f] border border-[#2a2a2a] rounded-lg p-3 flex justify-between text-sm">
+      <div className="bg-[#0f0f0f] border border-[#2a2a2a] rounded-lg p-3 flex items-center justify-between text-sm">
         <span className="text-gray-400">Total ({duration} min)</span>
-        <span className="font-bold text-white">₹{price}</span>
+        <span className="font-bold text-white text-lg">₹{price}</span>
       </div>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-red-500 bg-red-500/10 p-2 rounded border border-red-500/20">{error}</p>}
 
-      <div className="flex gap-2">
-        <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>Cancel</Button>
-        <Button type="submit" className="flex-1" disabled={loading}>
+      <div className="flex gap-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={loading} className="border-[#2a2a2a] bg-[#111111] hover:bg-[#1a1a1a]">Cancel</Button>
+        <Button type="submit" className="flex-1 bg-indigo-600 hover:bg-indigo-700" disabled={loading || !selectedDate || !selectedTime}>
           {loading ? 'Processing...' : `Pay ₹${price}`}
         </Button>
       </div>

--- a/frontend/src/components/pyqs/PYQCard.tsx
+++ b/frontend/src/components/pyqs/PYQCard.tsx
@@ -3,6 +3,8 @@ import { apiFetch } from '@/lib/api'
 
 export interface PYQTag {
   tag: { id: string; name: string }
+  upvote_count?: number
+  user_has_upvoted?: boolean
 }
 
 export interface PYQ {
@@ -23,6 +25,8 @@ export interface PYQ {
   uploader?: { display_name?: string | null; karma?: number | null } | null
   user_has_upvoted?: boolean
   user_has_downvoted?: boolean
+  average_difficulty?: number
+  user_rating?: number
 }
 
 interface Props {
@@ -68,9 +72,15 @@ export function PYQCard({ pyq, canDelete = false, onDelete, isDeleting = false }
   const [bookmarking, setBookmarking] = useState(false)
   const [openingFile, setOpeningFile] = useState(false)
   const authorName = pyq.is_anonymous ? 'Anonymous' : (pyq.uploader?.display_name || 'Student')
-  const visibleTags = pyq.tags?.slice(0, 3) ?? []
-  const moreTags = Math.max(0, (pyq.tags?.length ?? 0) - visibleTags.length)
   const commentCount = pyq.comment_count ?? 0
+
+  const [rating, setRating] = useState<number | undefined>(pyq.user_rating)
+  const [avgDifficulty, setAvgDifficulty] = useState<number | undefined>(pyq.average_difficulty)
+  const [tags, setTags] = useState<PYQTag[]>(pyq.tags || [])
+  const [tagInputOpen, setTagInputOpen] = useState(false)
+  const [newTag, setNewTag] = useState('')
+  const [ratingSubmitting, setRatingSubmitting] = useState(false)
+  const [tagSubmitting, setTagSubmitting] = useState(false)
 
   async function handleUpvote() {
     if (voting) return
@@ -137,6 +147,56 @@ export function PYQCard({ pyq, canDelete = false, onDelete, isDeleting = false }
       setOpeningFile(false)
     }
   }
+  async function handleRate(value: number) {
+    if (ratingSubmitting) return
+    setRatingSubmitting(true)
+    try {
+      const res = await apiFetch<{ rating: number; average_difficulty: number }>(`/api/pyqs/${pyq.id}/rate`, {
+        method: 'POST',
+        body: JSON.stringify({ rating: value })
+      })
+      setRating(res.rating)
+      setAvgDifficulty(res.average_difficulty)
+    } catch (error) {
+      console.error('Failed to rate PYQ', error)
+    } finally {
+      setRatingSubmitting(false)
+    }
+  }
+
+  async function handleAddTag(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newTag.trim() || tagSubmitting) return
+    setTagSubmitting(true)
+    try {
+      const res = await apiFetch<{ tag: PYQTag }>(`/api/pyqs/${pyq.id}/tags`, {
+        method: 'POST',
+        body: JSON.stringify({ name: newTag.trim() })
+      })
+      setTags([...tags, res.tag])
+      setNewTag('')
+      setTagInputOpen(false)
+    } catch (error) {
+      console.error('Failed to add tag', error)
+    } finally {
+      setTagSubmitting(false)
+    }
+  }
+
+  async function handleUpvoteTag(tagId: string) {
+    try {
+      const res = await apiFetch<{ upvoted: boolean; upvote_count: number }>(`/api/pyqs/${pyq.id}/tags/${tagId}/upvote`, {
+        method: 'POST'
+      })
+      setTags(tags.map(t => 
+        t.tag.id === tagId 
+          ? { ...t, user_has_upvoted: res.upvoted, upvote_count: res.upvote_count }
+          : t
+      ))
+    } catch (error) {
+      console.error('Failed to upvote tag', error)
+    }
+  }
 
   return (
     <div
@@ -196,6 +256,21 @@ export function PYQCard({ pyq, canDelete = false, onDelete, isDeleting = false }
               {pyq.exam_type}
             </span>
             <span className="text-xs text-gray-500">{pyq.year}</span>
+            <div className="ml-auto flex items-center gap-1" onClick={e => e.stopPropagation()}>
+              <span className="text-[10px] text-gray-500 mr-1">
+                {avgDifficulty ? `Difficulty: ${avgDifficulty.toFixed(1)}/5` : 'Rate difficulty:'}
+              </span>
+              {[1, 2, 3, 4, 5].map(star => (
+                <button
+                  key={star}
+                  disabled={ratingSubmitting}
+                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleRate(star); }}
+                  className={`text-[12px] transition-colors ${rating && star <= rating ? 'text-yellow-400 drop-shadow-[0_0_4px_rgba(250,204,21,0.5)]' : 'text-[#444444] hover:text-yellow-400'}`}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="mt-2">
@@ -206,19 +281,38 @@ export function PYQCard({ pyq, canDelete = false, onDelete, isDeleting = false }
             )}
           </div>
 
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {visibleTags.map(t => (
-              <span
+          <div className="mt-2 flex flex-wrap items-center gap-1.5" onClick={e => e.stopPropagation()}>
+            {tags.map(t => (
+              <button
                 key={t.tag.id}
-                className="rounded-full border border-[#444444] bg-[#222222] px-2 py-0.5 text-[10px] text-gray-300"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleUpvoteTag(t.tag.id) }}
+                className={`rounded-full border px-2 py-0.5 text-[10px] flex items-center gap-1 transition-colors ${t.user_has_upvoted ? 'border-[#6366f1]/50 bg-[#6366f1]/10 text-[#c7d2fe]' : 'border-[#444444] bg-[#222222] text-gray-300 hover:border-gray-500'}`}
               >
-                {t.tag.name}
-              </span>
+                {t.tag.name} <span className="opacity-50 text-[9px]">{t.upvote_count ?? 0}</span>
+              </button>
             ))}
-            {moreTags > 0 && (
-              <span className="rounded-full border border-[#444444] bg-[#222222] px-2 py-0.5 text-[10px] text-gray-300">
-                +{moreTags} more
-              </span>
+            
+            {tagInputOpen ? (
+              <form onSubmit={(e) => { e.stopPropagation(); handleAddTag(e); }} className="flex items-center gap-1">
+                <input
+                  type="text"
+                  autoFocus
+                  value={newTag}
+                  onChange={e => setNewTag(e.target.value)}
+                  onClick={e => e.stopPropagation()}
+                  onKeyDown={e => e.stopPropagation()}
+                  onBlur={() => setTimeout(() => setTagInputOpen(false), 200)}
+                  className="h-5 w-24 rounded bg-[#111111] px-1.5 text-[10px] text-white border border-[#444444] outline-none focus:border-[#6366f1]"
+                  placeholder="tag name..."
+                />
+              </form>
+            ) : (
+              <button
+                onClick={e => { e.preventDefault(); e.stopPropagation(); setTagInputOpen(true); }}
+                className="rounded-full border border-dashed border-[#444444] bg-transparent px-2 py-0.5 text-[10px] text-gray-400 hover:text-gray-200 hover:border-gray-400 transition-colors"
+              >
+                + Add Tag
+              </button>
             )}
           </div>
 

--- a/frontend/src/components/pyqs/PYQFeed.tsx
+++ b/frontend/src/components/pyqs/PYQFeed.tsx
@@ -17,6 +17,7 @@ interface Filters {
   exam_type?: string
   year?: string
   tag?: string
+  difficulty?: string
   sort?: 'recent' | 'upvotes'
 }
 
@@ -34,6 +35,7 @@ function buildUrl(filters: Filters, cursor?: string) {
   if (filters.exam_type) params.set('exam_type', filters.exam_type)
   if (filters.year) params.set('year', filters.year)
   if (filters.tag) params.set('tag', filters.tag)
+  if (filters.difficulty) params.set('difficulty', filters.difficulty)
   if (filters.sort) params.set('sort', filters.sort)
   if (cursor) params.set('cursor', cursor)
   const qs = params.toString()

--- a/frontend/src/components/pyqs/PYQFeed.tsx
+++ b/frontend/src/components/pyqs/PYQFeed.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { PYQCard, type PYQ } from './PYQCard'
+import { PYQSkeleton } from '../ui/skeleton'
 import { apiFetch } from '@/lib/api'
 import { usePYQRealtime } from '@/hooks/usePYQRealtime'
 
@@ -72,12 +73,9 @@ export function PYQFeed({ filters = {}, canDeletePyq = false, onDeletePyq, delet
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="space-y-0">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-32 rounded-lg border border-[#2a2a2a] bg-gradient-to-br from-[#1a1a1a] to-[#141414] animate-pulse"
-          />
+          <PYQSkeleton key={i} />
         ))}
       </div>
     )
@@ -117,12 +115,9 @@ export function PYQFeed({ filters = {}, canDeletePyq = false, onDeletePyq, delet
       <div ref={sentinelRef} className="h-4" />
 
       {isFetchingNextPage && (
-        <div className="space-y-3">
+        <div className="space-y-0 mt-2">
           {Array.from({ length: 2 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-32 rounded-lg border border-[#2a2a2a] bg-gradient-to-br from-[#1a1a1a] to-[#141414] animate-pulse"
-            />
+            <PYQSkeleton key={i} />
           ))}
         </div>
       )}

--- a/frontend/src/components/stories/StoriesBar.tsx
+++ b/frontend/src/components/stories/StoriesBar.tsx
@@ -43,6 +43,7 @@ interface StoryItem {
     avatar_url: string | null
     viewed_at: string
   }>
+  sticker_overlay?: string | null
 }
 
 interface StoryRing {
@@ -191,6 +192,11 @@ export function StoriesBar() {
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState('')
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showPhotoCaption, setShowPhotoCaption] = useState(false)
+  const [expiresIn, setExpiresIn] = useState<6 | 12 | 24>(24)
+  const [selectedSticker, setSelectedSticker] = useState<string | null>(null)
+  const [showStickerPicker, setShowStickerPicker] = useState(false)
+
+  const STICKERS = ['🔥', '💯', '💀', '😭', '❤️', '🎉', '👀', '🚀']
 
   const touchStartY = useRef<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -254,6 +260,8 @@ export function StoriesBar() {
       text_content?: string
       image_url?: string
       gradient_index?: number
+      expires_in_hours?: number
+      sticker_overlay?: string
     }) => apiFetch<{ story: StoryItem }>('/api/stories', {
         method: 'POST',
         body: JSON.stringify(payload),
@@ -269,6 +277,9 @@ export function StoriesBar() {
       setTextGradientIndex(0)
       setShowPhotoCaption(false)
       setUploadProgress(0)
+      setExpiresIn(24)
+      setSelectedSticker(null)
+      setShowStickerPicker(false)
       toast({ variant: 'success', title: 'Story shared! 🎉' })
     },
     onError: error => {
@@ -580,6 +591,8 @@ export function StoriesBar() {
         image_url: upload.url,
         text_content: photoCaption.trim() || undefined,
         gradient_index: textGradientIndex,
+        expires_in_hours: expiresIn,
+        sticker_overlay: selectedSticker ?? undefined,
       })
       setUploadProgress(100)
     } catch (error) {
@@ -604,6 +617,8 @@ export function StoriesBar() {
       content_type: 'text',
       text_content: textContent.trim(),
       gradient_index: textGradientIndex,
+      expires_in_hours: expiresIn,
+      sticker_overlay: selectedSticker ?? undefined,
     })
   }
 
@@ -678,6 +693,9 @@ export function StoriesBar() {
       setPhotoFile(null)
       setPhotoPreviewUrl('')
       setShowPhotoCaption(false)
+      setExpiresIn(24)
+      setSelectedSticker(null)
+      setShowStickerPicker(false)
     }
   }, [createOpen])
 
@@ -851,13 +869,48 @@ export function StoriesBar() {
                 </div>
               )}
 
-              <button
-                type="button"
-                onClick={() => setCreateOpen(false)}
-                className="absolute right-4 top-4 rounded-full bg-black/45 p-2 text-white"
-              >
-                <X className="h-5 w-5" />
-              </button>
+              <div className="absolute top-4 left-4 right-4 flex items-center justify-between z-50">
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowStickerPicker(p => !p)}
+                    className="rounded-full bg-black/45 px-3 py-1.5 text-sm text-white hover:bg-black/60"
+                  >
+                    Stickers
+                  </button>
+                  <select
+                    value={expiresIn}
+                    onChange={(e) => setExpiresIn(Number(e.target.value) as 6 | 12 | 24)}
+                    className="rounded-full bg-black/45 px-2 py-1.5 text-sm text-white outline-none cursor-pointer"
+                  >
+                    <option value={6}>6h Expiry</option>
+                    <option value={12}>12h Expiry</option>
+                    <option value={24}>24h Expiry</option>
+                  </select>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setCreateOpen(false)}
+                  className="rounded-full bg-black/45 p-2 text-white hover:bg-black/60"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              {showStickerPicker && (
+                <div className="absolute top-16 left-4 right-4 bg-black/80 backdrop-blur-sm rounded-2xl p-4 flex flex-wrap gap-3 justify-center z-50 border border-white/10">
+                  {STICKERS.map(s => (
+                    <button key={s} type="button" onClick={() => { setSelectedSticker(s); setShowStickerPicker(false) }} className="text-3xl hover:scale-110 transition-transform">{s}</button>
+                  ))}
+                  <button type="button" onClick={() => { setSelectedSticker(null); setShowStickerPicker(false) }} className="text-sm bg-white/20 hover:bg-white/30 rounded-full px-4 py-1 text-white">Clear</button>
+                </div>
+              )}
+
+              {selectedSticker && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+                  <span className="text-8xl drop-shadow-[0_4px_8px_rgba(0,0,0,0.5)]">{selectedSticker}</span>
+                </div>
+              )}
 
               <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-4">
                 <div className="flex items-center justify-between gap-2">
@@ -900,23 +953,57 @@ export function StoriesBar() {
               className="relative mx-auto flex h-[100dvh] w-full max-w-[480px] flex-col"
               style={{ background: storyGradients[textGradientIndex] }}
             >
-              <div className="flex items-center justify-between p-4">
+              <div className="flex items-center justify-between p-4 relative z-50">
                 <button
                   type="button"
                   onClick={() => setCreatorStep('choose')}
-                  className="rounded-full bg-black/35 px-3 py-1.5 text-sm"
+                  className="rounded-full bg-black/35 px-3 py-1.5 text-sm hover:bg-black/50"
                 >
                   Back
                 </button>
-                <button
-                  type="button"
-                  disabled={createMutation.isPending}
-                  onClick={() => { void shareTextStory() }}
-                  className="rounded-full bg-violet-600 px-4 py-1.5 text-sm font-semibold disabled:opacity-60"
-                >
-                  Share →
-                </button>
+                
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowStickerPicker(p => !p)}
+                    className="rounded-full bg-black/35 px-3 py-1.5 text-sm hover:bg-black/50"
+                  >
+                    Stickers
+                  </button>
+                  <select
+                    value={expiresIn}
+                    onChange={(e) => setExpiresIn(Number(e.target.value) as 6 | 12 | 24)}
+                    className="rounded-full bg-black/35 px-2 py-1.5 text-sm text-white outline-none cursor-pointer"
+                  >
+                    <option value={6} className="bg-black text-white">6h</option>
+                    <option value={12} className="bg-black text-white">12h</option>
+                    <option value={24} className="bg-black text-white">24h</option>
+                  </select>
+                  <button
+                    type="button"
+                    disabled={createMutation.isPending}
+                    onClick={() => { void shareTextStory() }}
+                    className="rounded-full bg-violet-600 px-4 py-1.5 text-sm font-semibold disabled:opacity-60 hover:bg-violet-500 transition-colors"
+                  >
+                    Share →
+                  </button>
+                </div>
               </div>
+
+              {showStickerPicker && (
+                <div className="absolute top-16 left-4 right-4 bg-black/80 backdrop-blur-sm rounded-2xl p-4 flex flex-wrap gap-3 justify-center z-50 border border-white/10">
+                  {STICKERS.map(s => (
+                    <button key={s} type="button" onClick={() => { setSelectedSticker(s); setShowStickerPicker(false) }} className="text-3xl hover:scale-110 transition-transform">{s}</button>
+                  ))}
+                  <button type="button" onClick={() => { setSelectedSticker(null); setShowStickerPicker(false) }} className="text-sm bg-white/20 hover:bg-white/30 rounded-full px-4 py-1 text-white">Clear</button>
+                </div>
+              )}
+
+              {selectedSticker && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+                  <span className="text-8xl drop-shadow-[0_4px_8px_rgba(0,0,0,0.5)]">{selectedSticker}</span>
+                </div>
+              )}
 
               <div className="flex flex-1 items-center justify-center px-6">
                 <textarea
@@ -1060,6 +1147,12 @@ export function StoriesBar() {
                       <p className="text-2xl font-bold">{activeStory.poll_question || 'Poll Story'}</p>
                       <p className="mt-3 text-sm text-white/80">This poll can be voted from the default poll feed UI.</p>
                     </div>
+                  </div>
+                )}
+
+                {activeStory.sticker_overlay && (
+                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-20">
+                    <span className="text-8xl drop-shadow-[0_4px_8px_rgba(0,0,0,0.5)]">{activeStory.sticker_overlay}</span>
                   </div>
                 )}
               </div>

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -24,13 +24,121 @@ export function Skeleton({ className, variant = 'rectangle', ...props }: Skeleto
 
 export function SkeletonCard() {
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 space-y-3">
-      <Skeleton className="h-40 w-full" />
-      <Skeleton variant="text" className="w-3/4" />
-      <Skeleton variant="text" className="w-1/2" />
-      <div className="flex gap-2">
-        <Skeleton variant="text" className="w-16 h-6 rounded-full" />
-        <Skeleton variant="text" className="w-16 h-6 rounded-full" />
+    <div className="group rounded-xl border border-[#2a2a2a] dark:border-gray-700 bg-[#1a1a1a] dark:bg-gray-800 overflow-hidden flex flex-col">
+      <div className="aspect-video w-full bg-[#222222] dark:bg-gray-700 animate-pulse" />
+      <div className="p-4 flex flex-col gap-3 flex-1">
+        <div className="flex gap-2">
+          <div className="h-5 w-16 bg-[#2a2a2a] dark:bg-gray-700 rounded-full animate-pulse" />
+        </div>
+        <div className="h-5 w-3/4 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+        <div className="flex flex-col gap-2 mt-1">
+          <div className="h-3 w-1/2 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-3 w-2/3 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <div className="mt-auto pt-4 flex items-center justify-between gap-2">
+          <div className="h-4 w-20 bg-[#2a2a2a] dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-8 w-24 bg-[#2a2a2a] dark:bg-gray-700 rounded-lg animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PYQSkeleton() {
+  return (
+    <div className="mb-2 flex overflow-hidden rounded-[12px] border border-[#2a2a2a]">
+      <div className="w-[40px] shrink-0 border-r border-[#2a2a2a] bg-[#111111]">
+        <div className="flex min-h-[124px] flex-col items-center justify-center gap-2 py-2">
+          <div className="h-3 w-3 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-3 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 bg-[#1a1a1a] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-4 w-14 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-3 w-8 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 space-y-2">
+          <div className="h-4 w-3/4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-1/2 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 flex gap-2">
+          <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+        </div>
+        <div className="my-3 h-px bg-[#2a2a2a]" />
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex gap-3">
+            <div className="h-3 w-16 bg-[#2a2a2a] rounded animate-pulse" />
+            <div className="h-3 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 bg-[#2a2a2a] rounded-full animate-pulse" />
+            <div className="h-3 w-16 bg-[#2a2a2a] rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ConfessionSkeleton() {
+  return (
+    <div className="mb-4 overflow-hidden rounded-2xl border border-[#242424] bg-[#121212] flex">
+      <div className="w-[42px] shrink-0 border-r border-[#232323] bg-[#101010]">
+        <div className="flex min-h-[128px] flex-col items-center justify-center gap-2 py-2">
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-5 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-4 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 bg-[#171717] px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+          <div className="h-3 w-20 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-3 space-y-2">
+          <div className="h-4 w-[90%] bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-[85%] bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-4 w-[60%] bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+        <div className="mt-4 flex gap-3 border-t border-[#242424] pt-3">
+          <div className="h-5 w-10 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-5 w-10 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-5 w-12 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PersonSkeleton() {
+  return (
+    <div className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+      <div className="flex items-center gap-3">
+        <div className="h-14 w-14 rounded-full bg-[#2a2a2a] animate-pulse shrink-0" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="h-4 w-3/4 bg-[#2a2a2a] rounded animate-pulse" />
+          <div className="h-3 w-1/2 bg-[#2a2a2a] rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="mt-3">
+        <div className="h-3 w-2/3 bg-[#2a2a2a] rounded animate-pulse" />
+      </div>
+      <div className="mt-3 flex gap-2">
+        <div className="h-4 w-16 bg-[#2a2a2a] rounded-full animate-pulse" />
+        <div className="h-4 w-12 bg-[#2a2a2a] rounded-full animate-pulse" />
+      </div>
+      <div className="mt-4 flex items-center justify-between">
+        <div className="h-5 w-14 bg-[#2a2a2a] rounded animate-pulse" />
+        <div className="h-4 w-20 bg-[#2a2a2a] rounded-full animate-pulse" />
+      </div>
+      <div className="mt-4 flex gap-2">
+        <div className="h-8 w-24 bg-[#2a2a2a] rounded-lg animate-pulse" />
+        <div className="h-8 w-24 bg-[#2a2a2a] rounded-lg animate-pulse" />
       </div>
     </div>
   )

--- a/frontend/src/hooks/useAthenaHistory.ts
+++ b/frontend/src/hooks/useAthenaHistory.ts
@@ -1,0 +1,95 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+import { useAuthStore } from '../store/auth'
+import type { AthenaPayload, AthenaAnswerMode, AITask } from '../services/aiService'
+
+export interface AthenaHistoryMessage {
+  id: string
+  user_id: string
+  task_type: AITask
+  role: 'user' | 'assistant'
+  content: string
+  provider?: 'groq' | 'gemini' | null
+  mode?: AthenaAnswerMode | null
+  athena_payload?: AthenaPayload | null
+  created_at: string
+}
+
+export function useAthenaHistory(taskType: AITask) {
+  const user = useAuthStore((s) => s.user)
+
+  return useQuery({
+    queryKey: ['athena_history', taskType],
+    queryFn: async (): Promise<AthenaHistoryMessage[]> => {
+      if (!user) return []
+
+      const { data, error } = await supabase
+        .from('athena_history')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('task_type', taskType)
+        .order('created_at', { ascending: true })
+        .limit(50)
+
+      if (error) {
+        console.warn('Failed to fetch athena history. Table might not exist yet:', error.message)
+        return []
+      }
+
+      return data as AthenaHistoryMessage[]
+    },
+    enabled: !!user,
+    staleTime: 1000 * 60 * 5, // 5 mins
+  })
+}
+
+export function useInsertAthenaHistory() {
+  const queryClient = useQueryClient()
+  const user = useAuthStore((s) => s.user)
+
+  return useMutation({
+    mutationFn: async (message: Omit<AthenaHistoryMessage, 'id' | 'user_id' | 'created_at'>) => {
+      if (!user) return null
+
+      const { data, error } = await supabase
+        .from('athena_history')
+        .insert([{ ...message, user_id: user.id }])
+        .select()
+        .single()
+
+      if (error) {
+        console.warn('Failed to insert athena history. Table might not exist yet:', error.message)
+        return null
+      }
+
+      return data as AthenaHistoryMessage
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['athena_history', variables.task_type] })
+    },
+  })
+}
+
+export function useClearAthenaHistory() {
+  const queryClient = useQueryClient()
+  const user = useAuthStore((s) => s.user)
+
+  return useMutation({
+    mutationFn: async (taskType: AITask) => {
+      if (!user) return
+
+      const { error } = await supabase
+        .from('athena_history')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('task_type', taskType)
+
+      if (error) {
+        console.warn('Failed to clear athena history:', error.message)
+      }
+    },
+    onSuccess: (_, taskType) => {
+      queryClient.invalidateQueries({ queryKey: ['athena_history', taskType] })
+    },
+  })
+}

--- a/frontend/src/lib/ics.ts
+++ b/frontend/src/lib/ics.ts
@@ -1,0 +1,92 @@
+export interface ICS_Event {
+  id: string
+  title: string
+  description?: string
+  date: string // YYYY-MM-DD
+  time?: string | null // HH:mm or null
+}
+
+function generateUID(id: string) {
+  return `${id}@pesimens.app`
+}
+
+function formatDate(dateStr: string, timeStr?: string | null): string {
+  const d = new Date(`${dateStr}T${timeStr || '00:00:00'}`)
+  
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const YYYY = d.getUTCFullYear()
+  const MM = pad(d.getUTCMonth() + 1)
+  const DD = pad(d.getUTCDate())
+  
+  if (!timeStr) {
+    return `${YYYY}${MM}${DD}`
+  }
+
+  const hh = pad(d.getUTCHours())
+  const mm = pad(d.getUTCMinutes())
+  const ss = pad(d.getUTCSeconds())
+
+  return `${YYYY}${MM}${DD}T${hh}${mm}${ss}Z`
+}
+
+export function generateICS(events: ICS_Event[]): string {
+  let ics = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//PESimens//Planner//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH'
+  ].join('\r\n') + '\r\n'
+
+  const now = formatDate(new Date().toISOString().split('T')[0], new Date().toISOString().split('T')[1].slice(0, 8))
+
+  for (const event of events) {
+    const dtstart = formatDate(event.date, event.time)
+    
+    // For all-day events, DTEND is exclusive so it must be the NEXT day.
+    // For timed events, let's assume a default duration of 1 hour if not specified.
+    let dtend = ''
+    if (!event.time) {
+      const nextDay = new Date(event.date)
+      nextDay.setDate(nextDay.getDate() + 1)
+      dtend = formatDate(nextDay.toISOString().split('T')[0])
+    } else {
+      const d = new Date(`${event.date}T${event.time}`)
+      d.setHours(d.getHours() + 1)
+      dtend = formatDate(d.toISOString().split('T')[0], d.toTimeString().slice(0, 8))
+    }
+
+    const uid = generateUID(event.id)
+    const summary = event.title.replace(/[\r\n]/g, ' ')
+    const description = (event.description || '').replace(/[\r\n]/g, '\\n')
+
+    ics += [
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `DTSTAMP:${now}`,
+      `DTSTART${!event.time ? ';VALUE=DATE' : ''}:${dtstart}`,
+      `DTEND${!event.time ? ';VALUE=DATE' : ''}:${dtend}`,
+      `SUMMARY:${summary}`,
+      description ? `DESCRIPTION:${description}` : null,
+      'END:VEVENT'
+    ].filter(Boolean).join('\r\n') + '\r\n'
+  }
+
+  ics += 'END:VCALENDAR\r\n'
+
+  return ics
+}
+
+export function downloadICS(events: ICS_Event[], filename = 'schedule.ics') {
+  const icsData = generateICS(events)
+  const blob = new Blob([icsData], { type: 'text/calendar;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -17,7 +17,7 @@ export function AuthCallbackPage() {
   const setProfileLoading = useAuthStore(s => s.setProfileLoading)
   const redirectAfterAuth = useExploreUIStore(s => s.redirectAfterAuth)
   const clearRedirectAfterAuth = useExploreUIStore(s => s.clearRedirectAfterAuth)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<{ message: string; isExpiredToken?: boolean } | null>(null)
   const [callbackComplete, setCallbackComplete] = useState(false)
   const [transitionLabel, setTransitionLabel] = useState('Signing you in...')
   const callbackExecutedRef = useRef(false)
@@ -34,7 +34,11 @@ export function AuthCallbackPage() {
         hashParams.get('error_description') || hashParams.get('error')
 
       if (errorDescription) {
-        setError(`Authentication failed. ${errorDescription}`)
+        const isExpired = errorDescription.toLowerCase().includes('expired') || errorDescription.toLowerCase().includes('invalid')
+        setError({
+          message: isExpired ? 'This login link has expired or is invalid.' : `Authentication failed. ${errorDescription}`,
+          isExpiredToken: isExpired
+        })
         setCallbackComplete(true)
         return
       }
@@ -47,7 +51,7 @@ export function AuthCallbackPage() {
         session = s
         if (!session) {
           console.error('Code exchange failed and no session present:', exchangeError?.message)
-          setError('Authentication failed. Please try again.')
+          setError({ message: 'Authentication failed. Please try again.' })
           setCallbackComplete(true)
           return
         }
@@ -65,7 +69,7 @@ export function AuthCallbackPage() {
             refresh_token: hashRefreshToken,
           })
           if (setSessionError) {
-            setError('Authentication failed. Please try again.')
+            setError({ message: 'Authentication failed. Please try again.' })
             setCallbackComplete(true)
             return
           }
@@ -81,7 +85,7 @@ export function AuthCallbackPage() {
         }
 
         if (!s) {
-          setError('Authentication failed. No authorization code found.')
+          setError({ message: 'Authentication failed. No authorization code found.' })
           setCallbackComplete(true)
           return
         }
@@ -143,7 +147,7 @@ export function AuthCallbackPage() {
       setCallbackComplete(true)
     } catch (err) {
       console.error('Callback error:', err)
-      setError('Something went wrong. Please try again.')
+      setError({ message: 'Something went wrong. Please try again.' })
       setCallbackComplete(true)
     }
   }, [setSession, setProfile, setProfileLoading])
@@ -193,11 +197,25 @@ export function AuthCallbackPage() {
   if (error) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-slate-950 px-4">
-        <div className="max-w-sm rounded-2xl border border-slate-700 bg-slate-900 px-6 py-5 text-center shadow-[0_18px_42px_-34px_rgba(0,0,0,0.55)]">
-          <p className="font-medium text-rose-400">{error}</p>
-          <a href="/login" className="mt-4 inline-block text-sm text-sky-400 hover:text-sky-300 transition-colors">
-            Back to login
-          </a>
+        <div className="max-w-sm w-full rounded-2xl border border-slate-700 bg-slate-900 px-6 py-8 text-center shadow-[0_18px_42px_-34px_rgba(0,0,0,0.55)]">
+          <div className="mb-4 mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-rose-500/10">
+            <span className="text-xl text-rose-500">⚠️</span>
+          </div>
+          <h2 className="mb-2 text-lg font-semibold text-white">Login Failed</h2>
+          <p className="font-medium text-slate-400 mb-6">{error.message}</p>
+          
+          {error.isExpiredToken ? (
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500"
+            >
+              Resend magic link
+            </button>
+          ) : (
+            <a href="/login" className="inline-block text-sm text-sky-400 hover:text-sky-300 transition-colors">
+              Back to login
+            </a>
+          )}
         </div>
       </div>
     )

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ChevronLeft, ChevronRight, Trash2, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Trash2, X, Download } from 'lucide-react'
 import { apiFetch } from '../lib/api'
 import { useToast } from '../components/ui/use-toast'
+import { downloadICS, type ICS_Event } from '../lib/ics'
 
 interface BirthdayItem {
   id: string
@@ -394,6 +395,48 @@ export default function CalendarPage() {
     return () => clearInterval(timer)
   }, [upcomingTasksQuery.data?.tasks])
 
+  const handleExportICS = () => {
+    const allEvents: ICS_Event[] = []
+
+    tasks.forEach(task => {
+      allEvents.push({
+        id: task.id,
+        title: `[Task] ${task.title}`,
+        description: task.description || '',
+        date: task.due_date,
+        time: task.due_time,
+      })
+    })
+
+    exams.forEach(exam => {
+      allEvents.push({
+        id: exam.id,
+        title: `[Exam] ${exam.subject_name} ${exam.exam_type}`,
+        description: `Venue: ${exam.venue || 'TBA'}`,
+        date: exam.exam_date,
+        time: exam.exam_time,
+      })
+    })
+
+    pesuExams.forEach(exam => {
+      allEvents.push({
+        id: exam.id,
+        title: `[PESU Exam] ${exam.subject_name} ${exam.exam_type}`,
+        description: `Venue: ${exam.venue || 'TBA'}\nTime: ${exam.start_time || 'TBA'} - ${exam.end_time || 'TBA'}`,
+        date: exam.exam_date,
+        time: exam.start_time,
+      })
+    })
+
+    if (allEvents.length === 0) {
+      toast({ variant: 'info', title: 'No events to export' })
+      return
+    }
+
+    downloadICS(allEvents, `pesimens-schedule-${monthKey}.ics`)
+    toast({ variant: 'success', title: 'Calendar exported successfully' })
+  }
+
   return (
     <div className="min-h-[calc(100vh-4rem)] bg-[#0f0f0f] px-4 py-5 text-white md:px-6">
       <div className="mx-auto max-w-7xl space-y-4">
@@ -412,18 +455,27 @@ export default function CalendarPage() {
           <section className="flex-1 space-y-4">
             <div className="rounded-2xl border border-[#2a2a2a] bg-[#111111] p-4">
               <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1))}
+                    className="rounded-lg p-2 text-indigo-300 transition hover:bg-indigo-500/20"
+                  >
+                    <ChevronLeft className="h-5 w-5" />
+                  </button>
+                  <h1 className="text-lg font-semibold">{MONTHS[currentMonth.getMonth()]} {currentMonth.getFullYear()}</h1>
+                  <button
+                    onClick={() => setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1))}
+                    className="rounded-lg p-2 text-indigo-300 transition hover:bg-indigo-500/20"
+                  >
+                    <ChevronRight className="h-5 w-5" />
+                  </button>
+                </div>
                 <button
-                  onClick={() => setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1))}
-                  className="rounded-lg p-2 text-indigo-300 transition hover:bg-indigo-500/20"
+                  onClick={handleExportICS}
+                  className="flex items-center gap-2 rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-3 py-1.5 text-sm font-medium text-indigo-300 transition hover:bg-indigo-500/20"
                 >
-                  <ChevronLeft className="h-5 w-5" />
-                </button>
-                <h1 className="text-lg font-semibold">{MONTHS[currentMonth.getMonth()]} {currentMonth.getFullYear()}</h1>
-                <button
-                  onClick={() => setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1))}
-                  className="rounded-lg p-2 text-indigo-300 transition hover:bg-indigo-500/20"
-                >
-                  <ChevronRight className="h-5 w-5" />
+                  <Download className="h-4 w-4" />
+                  <span className="hidden sm:inline">Export (.ics)</span>
                 </button>
               </div>
 

--- a/frontend/src/pages/ConfessionsPage.tsx
+++ b/frontend/src/pages/ConfessionsPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { ApiError, apiFetch } from '@/lib/api'
 import { cn, formatDistanceToNow } from '@/lib/utils'
 import { useToast } from '@/components/ui/use-toast'
+import { ConfessionSkeleton } from '@/components/ui/skeleton'
 import { useConfessionsRealtime } from '@/hooks/useConfessionsRealtime'
 import { useAuthStore } from '@/store/auth'
 
@@ -847,14 +848,9 @@ export default function ConfessionsPage() {
 
             <div>
               {confessionsQuery.isLoading && (
-                <div className="space-y-2">
+                <div className="space-y-0">
                   {safeArray(Array.from({ length: 3 })).map((_, idx) => (
-                    <div key={idx} className="overflow-hidden rounded-[12px] border border-[#2a2a2a]">
-                      <div className="flex h-[140px]">
-                        <div className="w-[44px] border-r border-[#2a2a2a] bg-[#111111]" />
-                        <div className="flex-1 animate-pulse bg-[#1a1a1a]" />
-                      </div>
-                    </div>
+                    <ConfessionSkeleton key={idx} />
                   ))}
                 </div>
               )}
@@ -1193,9 +1189,9 @@ export default function ConfessionsPage() {
               <div ref={loadMoreRef} className="h-4" />
 
               {confessionsQuery.isFetchingNextPage && (
-                <div className="space-y-2">
+                <div className="space-y-0 mt-4">
                   {safeArray(Array.from({ length: 2 })).map((_, idx) => (
-                    <div key={idx} className="h-24 animate-pulse rounded-xl border border-[#2a2a2a] bg-[#1a1a1a]" />
+                    <ConfessionSkeleton key={idx} />
                   ))}
                 </div>
               )}

--- a/frontend/src/pages/ConfessionsPage.tsx
+++ b/frontend/src/pages/ConfessionsPage.tsx
@@ -194,6 +194,7 @@ export default function ConfessionsPage() {
   const [selectedCategory, setSelectedCategory] = useState<CategoryFilter>('all')
   const [feedSort, setFeedSort] = useState<FeedSort>('new')
   const [postOpen, setPostOpen] = useState(false)
+  const [isFullyAnonymous, setIsFullyAnonymous] = useState(true)
   const [content, setContent] = useState('')
   const [postCategory, setPostCategory] = useState<Category>('confession')
   const [bannerDismissed, setBannerDismissed] = useState(false)
@@ -364,7 +365,7 @@ export default function ConfessionsPage() {
   ])
 
   const createMutation = useMutation({
-    mutationFn: (payload: { content: string; category: Category }) =>
+    mutationFn: (payload: { content: string; category: Category; isFullyAnonymous: boolean }) =>
       apiFetch<CreateConfessionResponse>('/api/confessions', {
         method: 'POST',
         body: JSON.stringify(payload),
@@ -632,7 +633,7 @@ export default function ConfessionsPage() {
   function handleSubmitPost() {
     const trimmed = content.trim()
     if (!trimmed) return
-    createMutation.mutate({ content: trimmed, category: postCategory })
+    createMutation.mutate({ content: trimmed, category: postCategory, isFullyAnonymous })
   }
 
   function getCommentDeleteKey(confessionId: string, commentId: string) {
@@ -1305,6 +1306,37 @@ export default function ConfessionsPage() {
                 })}
               </select>
               <span className="text-xs text-white/45">{content.length}/500</span>
+            </div>
+
+            <div className="mt-4 rounded-lg border border-[#2a2a2a] bg-[#111111] p-3">
+              <div className="flex items-center justify-between">
+                <div className="pr-4">
+                  <p className="text-sm font-medium text-white">Fully anonymous mode</p>
+                  <p className="mt-0.5 text-xs text-gray-400">
+                    {isFullyAnonymous
+                      ? "No user ID stored. Moderated via IP hash only."
+                      : "Pseudonymous. Account ID linked for moderation but hidden from public."}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={isFullyAnonymous}
+                  onClick={() => setIsFullyAnonymous(!isFullyAnonymous)}
+                  className={cn(
+                    "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-[#1a1a1a]",
+                    isFullyAnonymous ? "bg-indigo-600" : "bg-[#2a2a2a]"
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                      isFullyAnonymous ? "translate-x-5" : "translate-x-0"
+                    )}
+                  />
+                </button>
+              </div>
             </div>
 
             <Button

--- a/frontend/src/pages/MentorsPage.tsx
+++ b/frontend/src/pages/MentorsPage.tsx
@@ -8,6 +8,7 @@ import { MentorCard, type Mentor } from '@/components/mentors/MentorCard'
 import { MentorApplicationForm } from '@/components/mentors/MentorApplicationForm'
 import { BookingForm } from '@/components/mentors/BookingForm'
 import { RatingForm } from '@/components/mentors/RatingForm'
+import { AvailabilityManager } from '@/components/mentors/AvailabilityManager'
 import { apiFetch, ApiError } from '@/lib/api'
 import { useAuthStore } from '@/store/auth'
 import { useEffect, useRef, useCallback } from 'react'
@@ -44,7 +45,8 @@ export function MentorsPage() {
   const [deleteReason, setDeleteReason] = useState('')
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
-  const [tab, setTab] = useState<'browse' | 'bookings'>('browse')
+  const isMentor = profile?.role === 'mentor'
+  const [tab, setTab] = useState<'browse' | 'bookings' | 'manage-availability'>('browse')
   const sentinelRef = useRef<HTMLDivElement>(null)
 
   const mentorsQuery = useInfiniteQuery({
@@ -65,6 +67,17 @@ export function MentorsPage() {
     queryKey: ['my-bookings'],
     queryFn: () => apiFetch<{ bookings: Booking[] }>('/api/mentors/me/bookings'),
     enabled: tab === 'bookings',
+  })
+
+  const updateStatusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) =>
+      apiFetch(`/api/bookings/${id}/status`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-bookings'] })
+    },
   })
 
   const handleDeleteMentor = async () => {
@@ -136,19 +149,19 @@ export function MentorsPage() {
         </div>
 
         {/* Tabs */}
-        <div className="flex w-full gap-1 rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-1 sm:w-fit">
-          {(['browse', 'bookings'] as const).map(t => (
+        <div className="flex w-full gap-1 rounded-xl border border-[#2a2a2a] bg-[#1a1a1a] p-1 sm:w-fit overflow-x-auto">
+          {(isMentor ? ['browse', 'bookings', 'manage-availability'] as const : ['browse', 'bookings'] as const).map(t => (
             <button
               key={t}
               onClick={() => setTab(t)}
               className={[
-                'rounded-lg px-4 py-2 text-sm font-semibold transition-all duration-200',
+                'rounded-lg px-4 py-2 text-sm font-semibold transition-all duration-200 whitespace-nowrap',
                 tab === t
                   ? 'bg-[#6366f1]/15 text-white ring-1 ring-[#6366f1]/30'
                   : 'text-white/60 hover:bg-[#1a1a1a]/5 hover:text-white/80',
               ].join(' ')}
             >
-              {t === 'browse' ? 'Browse Mentors' : 'My Bookings'}
+              {t === 'browse' ? 'Browse Mentors' : t === 'bookings' ? 'My Bookings' : 'Manage Availability'}
             </button>
           ))}
         </div>
@@ -272,8 +285,54 @@ export function MentorsPage() {
                 {b.status === 'completed' && (
                   <RatingForm bookingId={b.id} onSuccess={() => queryClient.invalidateQueries({ queryKey: ['my-bookings'] })} />
                 )}
+                
+                <div className="mt-3 flex gap-2">
+                  {b.mentor_id === profile?.id ? (
+                    // User is the mentor for this booking
+                    b.status === 'pending' && (
+                      <>
+                        <Button 
+                          size="sm" 
+                          className="bg-green-600 text-white hover:bg-green-700"
+                          onClick={() => updateStatusMutation.mutate({ id: b.id, status: 'confirmed' })}
+                          disabled={updateStatusMutation.isPending}
+                        >
+                          Accept
+                        </Button>
+                        <Button 
+                          size="sm" 
+                          variant="outline" 
+                          className="border-red-500/50 text-red-400 hover:bg-red-500/10"
+                          onClick={() => updateStatusMutation.mutate({ id: b.id, status: 'cancelled' })}
+                          disabled={updateStatusMutation.isPending}
+                        >
+                          Decline
+                        </Button>
+                      </>
+                    )
+                  ) : (
+                    // User is the student
+                    (b.status === 'pending' || b.status === 'confirmed') && (
+                      <Button 
+                        size="sm" 
+                        variant="outline" 
+                        className="border-red-500/50 text-red-400 hover:bg-red-500/10"
+                        onClick={() => updateStatusMutation.mutate({ id: b.id, status: 'cancelled' })}
+                        disabled={updateStatusMutation.isPending}
+                      >
+                        Cancel Booking
+                      </Button>
+                    )
+                  )}
+                </div>
               </div>
             ))}
+          </div>
+        )}
+
+        {tab === 'manage-availability' && (
+          <div className="pt-2">
+            <AvailabilityManager />
           </div>
         )}
 

--- a/frontend/src/pages/PYQsPage.tsx
+++ b/frontend/src/pages/PYQsPage.tsx
@@ -90,6 +90,8 @@ export function PYQsPage() {
     course: '',
     subject: '',
     exam_type: '',
+    tag: '',
+    difficulty: '',
     sort: 'recent' as 'recent' | 'upvotes',
   })
   const [subjectInput, setSubjectInput] = useState('')
@@ -137,6 +139,8 @@ export function PYQsPage() {
     ...(filters.course && { course: filters.course }),
     ...(filters.subject && { subject: filters.subject }),
     ...(filters.exam_type && { exam_type: filters.exam_type }),
+    ...(filters.tag && { tag: filters.tag }),
+    ...(filters.difficulty && { difficulty: filters.difficulty }),
     sort: filters.sort,
   }
 
@@ -329,8 +333,8 @@ function FilterPanel({
   materialsLoading,
   activeSubject,
 }: {
-  filters: { course: string; subject: string; exam_type: string; sort: 'recent' | 'upvotes' }
-  setFilters: React.Dispatch<React.SetStateAction<{ course: string; subject: string; exam_type: string; sort: 'recent' | 'upvotes' }>>
+  filters: { course: string; subject: string; exam_type: string; tag: string; difficulty: string; sort: 'recent' | 'upvotes' }
+  setFilters: React.Dispatch<React.SetStateAction<{ course: string; subject: string; exam_type: string; tag: string; difficulty: string; sort: 'recent' | 'upvotes' }>>
   subjectInput: string
   setSubjectInput: React.Dispatch<React.SetStateAction<string>>
   applyFilters: () => void
@@ -367,6 +371,24 @@ function FilterPanel({
             </option>
           ))}
         </select>
+
+        <select
+          className="h-10 w-full rounded-lg border border-[#2a2a2a] bg-[#111111] px-3 text-sm text-white outline-none focus:border-[#6366f1]"
+          value={filters.difficulty}
+          onChange={e => setFilters(f => ({ ...f, difficulty: e.target.value }))}
+        >
+          <option value="">Any Difficulty</option>
+          <option value="1-2">Easy (1-2 Stars)</option>
+          <option value="3-4">Medium (3-4 Stars)</option>
+          <option value="4-5">Hard (4-5 Stars)</option>
+        </select>
+
+        <Input
+          className="h-10 w-full rounded-lg border-[#2a2a2a] bg-[#111111] px-3 text-white placeholder:text-white/40 focus-visible:border-[#6366f1]"
+          placeholder="Filter by tag (e.g. recursion)"
+          value={filters.tag}
+          onChange={e => setFilters(f => ({ ...f, tag: e.target.value }))}
+        />
 
         <div className="flex gap-2">
           <Input

--- a/frontend/src/pages/PeoplePage.tsx
+++ b/frontend/src/pages/PeoplePage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { UserCheck, Users } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { UserAvatar } from '@/components/ui/avatar'
+import { PersonSkeleton } from '@/components/ui/skeleton'
 import { KarmaBadge } from '@/components/common/KarmaBadge'
 import { FollowButton } from '@/components/common/FollowButton'
 import { Link, useSearchParams } from 'react-router-dom'
@@ -129,7 +130,10 @@ export default function PeoplePage() {
             </div>
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {people.map(person => (
+              {query.isLoading ? (
+                Array.from({ length: 6 }).map((_, i) => <PersonSkeleton key={i} />)
+              ) : (
+                people.map(person => (
                 <div key={person.id} className="rounded-2xl border border-[#2a2a2a] bg-[#1a1a1a] p-4">
                   <div className="flex items-center gap-3">
                     <UserAvatar name={person.display_name} avatarUrl={person.avatar_url} className="h-14 w-14" />
@@ -165,10 +169,10 @@ export default function PeoplePage() {
                     )}
                   </div>
                 </div>
-              ))}
+              )))}
             </div>
 
-            {people.length === 0 && (
+            {!query.isLoading && people.length === 0 && (
               <p className="py-12 text-center text-sm text-white/60">No people found for current filters.</p>
             )}
           </>


### PR DESCRIPTION
**Issue**: #60 
# Summary

- [x] I linked the issue this PR addresses
- [x] I targeted `dev` as the base branch unless instructed otherwise
- [x] I kept the change scoped to one issue
- [ ] I added screenshots or recordings for UI changes
- [x] I added testing notes

## What changed
- **Supabase Memory Layer**: Created `useAthenaHistory.ts` with React Query hooks to interface directly with an `athena_history` Supabase table.
- **Background Sync**: Hooked into the chat submission and AI response streams within `AIChatPanel` to seamlessly persist complex JSON payloads (including mathematical formulas and formatting) to the cloud automatically.
- **Intelligent Context Resumption**: The Chat Panel now automatically pulls the user's last 50 messages on load, segregated by task mode (e.g., General chat history doesn't bleed into PYQ Explanations).
- **History Wipe UI**: Added a "Trash" icon to the top header of the chat panel allowing users to instantly wipe their conversation history for the current mode.

## Why this change is needed
Previously, Athena acted completely statelessly. Students who were in the middle of a complex multi-part explanation would lose all context if they closed the panel or refreshed the PWA. With conversational memory, Athena sessions persist across desktop and mobile gracefully, mimicking modern AI assistants.

## Testing

- [ ] Not tested (explain why)
- [x] Manually tested
- [ ] Added/updated automated tests

**Testing Notes**:
Verified messages are properly captured in local state and mapped accurately to the `athena_history` table schema. Verified loading spinner renders correctly during initial fetch. Verified that clicking the Trash icon successfully clears the query cache and local state.

## Screenshots (if applicable)
*(Add a screenshot of the new Trash/Clear History button in the Athena header here!)*
