### PR TITLE
fix: improve SellNoteModal accessibility

### DIFF
--- a/frontend/src/components/notes/SellNoteModal.tsx
+++ b/frontend/src/components/notes/SellNoteModal.tsx
@@ -124,6 +124,15 @@ export function SellNoteModal({ open, onClose, onSuccess }: Props) {
           <div
             className="cursor-pointer rounded-lg border border-dashed border-[#2a2a2a] bg-[#0f0f0f] p-4 text-center text-sm text-white/60 hover:border-[#6366f1]/60"
             onClick={() => fileRef.current?.click()}
+            role="button"
+            aria-label="Upload file dropzone"
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                fileRef.current?.click()
+              }
+            }}
           >
             <input
               ref={fileRef}


### PR DESCRIPTION
## What changed

Added keyboard and screen-reader support to the PDF upload dropzone in `SellNoteModal.tsx`:
- `role="button"` so assistive tech announces it as interactive
- `aria-label="Upload file dropzone"` for an accessible name
- `tabIndex={0}` so it's reachable via Tab
- `onKeyDown` handler that opens the file picker on Enter or Space

This mirrors the existing accessible dropzone pattern already used in `UploadPYQModal.tsx`.

## Why this change is needed

The dropzone was a plain `<div>` with only an `onClick` handler, so keyboard-only and screen-reader users had no way to open the file picker and upload a PDF — blocking the "Sell Notes" flow entirely for them. This violates WCAG 2.1 (2.1.1 Keyboard, 4.1.2 Name/Role/Value).

## Testing

- [x] Manually tested

Verified by tabbing through the "Sell Your Notes" modal and confirming the dropzone receives focus, exposes an accessible name via a screen reader, and opens the native file picker on both Enter and Space.
