### PR TITLE
refactor: remove @ts-nocheck from AIChatPanel.tsx and resolve all TypeScript violations

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -5,22 +5,8 @@
  * Supports SSE streaming with graceful fallback to non-streaming POST.
  * Requirements: 17.1-17.9
  */
-
-// @ts-nocheck
-
-// @ts-ignore TS: allow unresolved imports in this workspace environment
-import React, { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-// @ts-ignore TS: allow unresolved imports in this workspace environment
+import { useEffect, useMemo, useRef, useState, type ReactNode, type FormEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { Send, X, Loader2, Copy, Check, BookmarkCheck, Sparkles, Trash2 } from 'lucide-react'
-
-// Minimal local JSX declaration to satisfy TypeScript when React types are unavailable.
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      [elemName: string]: any
-    }
-  }
-}
 import { useAI, getAIErrorMessage } from '../../hooks/useAI'
 import { askAIStream } from '../../services/aiService'
 import { useAthenaHistory, useInsertAthenaHistory, useClearAthenaHistory } from '../../hooks/useAthenaHistory'
@@ -1134,15 +1120,15 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
     )
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
     submitPrompt(input)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit(e as unknown as React.FormEvent)
+      handleSubmit(e as unknown as FormEvent)
     }
   }
 


### PR DESCRIPTION
Closes #21

## What changed
- Removed `// @ts-nocheck` directive from the top of `AIChatPanel.tsx`
- Removed both `// @ts-ignore` comments suppressing React and lucide-react imports
- Removed the `declare global { namespace JSX { IntrinsicElements } }` workaround — unnecessary with `"jsx": "react-jsx"` in tsconfig (React 17+ automatic JSX transform)
- Removed `import React` — not needed with automatic JSX transform
- Added proper `type FormEvent` and `type KeyboardEvent as ReactKeyboardEvent` imports from react
- Fixed all resulting TypeScript references (`React.FormEvent` → `FormEvent`, `React.KeyboardEvent` → `ReactKeyboardEvent`)
- Verified zero TypeScript errors in AIChatPanel.tsx after changes (`npx tsc --noEmit` clean)

## Why this change is needed
`@ts-nocheck` silenced the TypeScript compiler entirely for the core 1,400-line AI chat component, meaning type errors, unsafe prop accesses, and broken imports went completely undetected. Full type coverage here guards against runtime crashes in the AI chat flow.

## Testing
- Ran `npx tsc --noEmit` — no errors in AIChatPanel.tsx
- No behavioral changes — refactor only, zero new functionality