### PR TITLE
feat: add loading skeleton to ProfilePage replacing plain text loader

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ImageLightbox } from '@/components/common/ImageLightbox'
 import { ExternalLink, Github, Globe, Instagram, Link2, Plus, Star, Trash2, Upload } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { PersonSkeleton } from '@/components/ui/skeleton'
 import { DetailBackButton } from '@/components/common/DetailBackButton'
 import { KarmaBadge } from '@/components/common/KarmaBadge'
 import { StreakBadge } from '@/components/common/StreakBadge'
@@ -327,11 +328,17 @@ export default function ProfilePage() {
     void queryClient.invalidateQueries({ queryKey: ['profile-followers', viewedProfileId] })
     void queryClient.invalidateQueries({ queryKey: ['profile-following', viewedProfileId] })
   }
-
   if (!viewedProfile) {
-    return <div className="p-6 text-white">Loading profile...</div>
-  }
-
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-6">
+      <div className="mb-3 h-8 w-24 rounded-lg bg-[#2a2a2a] animate-pulse" />
+      <PersonSkeleton />
+      <PersonSkeleton />
+      <PersonSkeleton />
+    </div>
+  )
+}
+  
   const links = {
     linkedin: viewedProfile.linkedin_url,
     instagram: viewedProfile.instagram_url,


### PR DESCRIPTION
Closes #121

## What changed
- Imported `PersonSkeleton` from `@/components/ui/skeleton` in `ProfilePage.tsx`
- Replaced `return <div className="p-6 text-white">Loading profile...</div>` with a proper skeleton layout using the existing `PersonSkeleton` component
- Shows 3 skeleton cards while profile data is being fetched

## Why this change is needed
The ProfilePage showed plain text "Loading profile..." while data loaded, giving users the impression the page was broken. The skeleton provides a content-shaped placeholder that improves perceived performance.

## Testing
- Navigate to any profile page — skeleton shows while data loads then transitions to real content
- No behavioral changes — UI improvement only