### PR TITLE
docs: remove leftover privacy template boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,15 +424,6 @@ Security issues should be reported through the maintainer contact listed above o
 - Example configuration files are only templates.
 - Uploaded files, logs, and build outputs should remain outside version control.
 
-If you want to publish a privacy policy, it should explain:
-
-- what user data is collected
-- why it is collected
-- where it is stored
-- how long it is retained
-- who can access it
-- how users can request deletion or support
-
 ---
 
 ## ❓ FAQ


### PR DESCRIPTION
# Summary

- [ ] I linked the issue this PR addresses
- [x] I targeted `dev` as the base branch unless instructed otherwise
- [x] I kept the change scoped to one issue
- [ ] I added screenshots or recordings for UI changes
- [x] I added testing notes

## What changed
Removed leftover instructional boilerplate text from the `## 🔐 Privacy` section of the README.

## Why this change is needed
The template placeholder text (starting with *"If you want to publish a privacy policy, it should explain:"*) was accidentally left in the README. Removing it ensures the documentation looks clean, finished, and only contains the actual privacy rules for the repository.

## Testing

- [ ] Not tested (explain why)
- [x] Manually tested
- [ ] Added/updated automated tests

**Testing notes:**
Verified the markdown changes locally to ensure the section renders cleanly without the boilerplate text.

## Screenshots (if applicable)
N/A