### PR TITLE
fix: add Escape key shortcut to close AIChatPanel

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -1044,6 +1044,17 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
     }
   }, [])
 
+  // Close panel on Escape key press for keyboard accessibility
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
   const starterPrompts = useMemo(() => {
     if (mode === 'general') {
       return [


### PR DESCRIPTION
## Summary

Fixes #124

The AIChatPanel could only be closed by clicking the X button with a mouse. Keyboard users had no way to dismiss the panel, which was an accessibility gap.

## Changes

- Added a `useEffect` hook that listens for `keydown` events on `document`
- When the `Escape` key is pressed, calls `onClose()` to dismiss the panel
- Properly cleans up the event listener on unmount
- Follows standard modal/panel UX patterns for keyboard accessibility

## Testing

- [x] Opening the AI chat panel and pressing Escape closes it
- [x] Other keyboard shortcuts are not affected
- [x] The existing X button close still works
- [x] No event listener leaks (cleanup on unmount)