### PR TITLE
fix: close AI chat panel with Escape

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -1012,6 +1012,17 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
   }, [])
 
   useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  useEffect(() => {
     if (typeof window === 'undefined') return
     const updateViewportType = () => setIsMobileViewport(window.matchMedia('(max-width: 767px)').matches)
     updateViewportType()

--- a/frontend/src/components/ai/__tests__/AIChatPanel.test.tsx
+++ b/frontend/src/components/ai/__tests__/AIChatPanel.test.tsx
@@ -59,6 +59,15 @@ describe('AIChatPanel', () => {
       await userEvent.click(screen.getByRole('button', { name: /close/i }))
       expect(onClose).toHaveBeenCalledOnce()
     })
+
+    it('closes when Escape is pressed', async () => {
+      const onClose = vi.fn()
+      render(<AIChatPanel {...defaultProps} onClose={onClose} />)
+
+      await userEvent.keyboard('{Escape}')
+
+      expect(onClose).toHaveBeenCalledOnce()
+    })
   })
 
   // Req 17.2 — accepts taskType, context, onClose props


### PR DESCRIPTION
## Summary
- close the AI chat panel when the Escape key is pressed
- remove the global key listener when the panel unmounts
- add a focused regression test

## Validation
- `git diff --check` passed
- `npx vitest run src/components/ai/__tests__/AIChatPanel.test.tsx` attempted; the existing test setup fails before assertions because `QueryClientProvider` is missing
- `npm run build` remains blocked by pre-existing JSX errors in `src/components/layout/Sidebar.tsx`
- `npm run lint` reports pre-existing repository-wide violations

Closes #124