### PR TITLE
feat: add toast notifications for copy actions (closes #146)

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -25,6 +25,7 @@ import { useAI, getAIErrorMessage } from '../../hooks/useAI'
 import { askAIStream } from '../../services/aiService'
 import { useAthenaHistory, useInsertAthenaHistory, useClearAthenaHistory } from '../../hooks/useAthenaHistory'
 import { useAuthStore } from '@/store/auth'
+import { useToast } from '@/components/ui/use-toast'
 import type { AITask, AIResponse, AthenaAnswerMode, AthenaPayload } from '../../services/aiService'
 
 export interface AIChatPanelProps {
@@ -940,6 +941,7 @@ function recoverAthenaFromContent(content: string): AthenaPayload | null {
 }
 
 export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AIChatPanelProps) {
+  const { toast } = useToast()
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<Message[]>([])
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null)
@@ -1174,14 +1176,22 @@ export function AIChatPanel({ taskType, context, onClose, mode = 'exam' }: AICha
 
   const handleCopyMessage = async (content: string, messageIndex: number) => {
     const copied = await copyText(content)
-    if (!copied) return
+    if (!copied) {
+      toast({ variant: 'error', title: 'Could not copy to clipboard' })
+      return
+    }
+    toast({ variant: 'success', title: 'Copied to clipboard! ✅' })
     setCopiedMessageIndex(messageIndex)
     window.setTimeout(() => setCopiedMessageIndex((prev) => (prev === messageIndex ? null : prev)), 1600)
   }
 
   const handleCopyCode = async (code: string, codeKey: string) => {
     const copied = await copyText(code)
-    if (!copied) return
+    if (!copied) {
+      toast({ variant: 'error', title: 'Could not copy to clipboard' })
+      return
+    }
+    toast({ variant: 'success', title: 'Copied to clipboard! ✅' })
     setCopiedCodeKey(codeKey)
     window.setTimeout(() => setCopiedCodeKey((prev) => (prev === codeKey ? null : prev)), 1600)
   }

--- a/frontend/src/pages/ConfessionsPage.tsx
+++ b/frontend/src/pages/ConfessionsPage.tsx
@@ -530,17 +530,17 @@ export default function ConfessionsPage() {
     setExpandedId(confessionId)
     fetchComments(confessionId)
   }
-
-  async function handleShare(confessionId: string, confessionText: string) {
+   async function handleShare(confessionId: string, confessionText: string) {
     try {
       await navigator.clipboard.writeText(confessionText)
       setCopiedShareId(confessionId)
+      toast({ variant: 'success', title: 'Copied to clipboard! ✅' })
       setTimeout(() => setCopiedShareId(prev => (prev === confessionId ? null : prev)), 1500)
     } catch {
       toast({ variant: 'error', title: 'Could not copy to clipboard' })
     }
   }
-
+  
   async function handleReport(confessionId: string) {
     try {
       await apiFetch(`/api/confessions/${confessionId}/flag`, { method: 'POST' })

--- a/frontend/src/pages/PESBluffPage.tsx
+++ b/frontend/src/pages/PESBluffPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { apiFetch } from '@/lib/api'
 import { useGameSession, type GameSession } from '@/hooks/useGameSession'
 import { useAuthStore } from '@/store/auth'
+import { useToast } from '@/components/ui/use-toast'
 import { BLUFF_QUESTIONS } from '@/data/bluffQuestions'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -186,6 +187,7 @@ export default function PESBluffPage() {
   const [localError, setLocalError] = useState<string | null>(null)
   const [showReveal, setShowReveal] = useState<LastReveal | null>(null)
   const [copied, setCopied] = useState(false)
+  const { toast } = useToast()
   const [showHistory, setShowHistory] = useState(false)
   const [entryTab, setEntryTab] = useState<'join' | 'public'>('join')
   const [publicRooms, setPublicRooms] = useState<PublicRoom[]>([])
@@ -307,9 +309,15 @@ export default function PESBluffPage() {
   }
   async function copyRoomCode() {
     if (!roomCode) return
-    try { await navigator.clipboard.writeText(roomCode); setCopied(true); setTimeout(() => setCopied(false), 1500) } catch { /* */ }
+    try {
+      await navigator.clipboard.writeText(roomCode)
+      setCopied(true)
+      toast({ variant: 'success', title: 'Copied to clipboard! ✅' })
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast({ variant: 'error', title: 'Could not copy to clipboard' })
+    }
   }
-
   // ══════════════════════════════════════════════════════════════════════════
   // SCREEN: Entry / No session
   // ══════════════════════════════════════════════════════════════════════════

--- a/frontend/src/pages/PESDrawlPage.tsx
+++ b/frontend/src/pages/PESDrawlPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameSession, type GameSession } from '@/hooks/useGameSession'
 import { useAuthStore } from '@/store/auth'
+import { useToast } from '@/components/ui/use-toast'
 import { DrawCanvas } from '@/components/games/drawl/DrawCanvas'
 import { GuessChat } from '@/components/games/drawl/GuessChat'
 import { PlayerList } from '@/components/games/drawl/PlayerList'
@@ -132,6 +133,7 @@ export default function PESDrawlPage() {
   const [joinCode, setJoinCode] = useState('')
   const [localError, setLocalError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const { toast } = useToast()
   const [elapsed, setElapsed] = useState(0)
   const [roundEndCountdown, setRoundEndCountdown] = useState<number | null>(null)
   const initRef = useRef<string | null>(null)
@@ -384,11 +386,14 @@ export default function PESDrawlPage() {
  
   async function copyRoomCode() {
     if (!roomCode) return
-    try {
+   try {
       await navigator.clipboard.writeText(roomCode)
       setCopied(true)
+      toast({ variant: 'success', title: 'Copied to clipboard! ✅' })
       setTimeout(() => setCopied(false), 1500)
-    } catch { }
+    } catch {
+      toast({ variant: 'error', title: 'Could not copy to clipboard' })
+    }
   }
  
   const revealedIndices = gameState.currentWord && gameState.roundStartedAt


### PR DESCRIPTION
## What this PR does
Adds success/error toast feedback whenever a user copies text to clipboard, using the app's existing toast system (`useToast` from `@/components/ui/use-toast`) — no new dependency needed, since `react-hot-toast`/`sonner` would duplicate what's already built.

## Where it was added
- `pages/ConfessionsPage.tsx` — sharing a confession (added success toast; error toast already existed)
- `components/ai/AIChatPanel.tsx` — copying an AI message or code block
- `pages/PESBluffPage.tsx` — copying the room code
- `pages/PESDrawlPage.tsx` — copying the room code (previously failed silently on error — now shows an error toast too)

## Why not react-hot-toast/sonner
The app already has a toast system used elsewhere (ShareButton, MarketplaceDetailPage). Reusing it keeps the bundle smaller and stays consistent with existing patterns.

Closes #146